### PR TITLE
support SPARK_HOME explicitly in override

### DIFF
--- a/modules/kernel/src/main/scala-2.10/notebook/ReplCalculator.scala
+++ b/modules/kernel/src/main/scala-2.10/notebook/ReplCalculator.scala
@@ -441,7 +441,7 @@ class ReplCalculator(
     val SparkConfScript = {
       val m = customSparkConf .getOrElse(Map.empty[String, String])
       m .map { case (k, v) =>
-        "( \"" + k + "\"  → \"" + v + "\" )"
+        "( \"" + k + "\"  → \"\"\"" + v + "\"\"\" )"
       }.mkString(",")
     }
 

--- a/modules/kernel/src/main/scala-2.11/notebook/ReplCalculator.scala
+++ b/modules/kernel/src/main/scala-2.11/notebook/ReplCalculator.scala
@@ -453,7 +453,7 @@ class ReplCalculator(
     val SparkConfScript = {
       val m = customSparkConf .getOrElse(Map.empty[String, String])
       m .map{ case (k, v) =>
-          "( \"" + k + "\"  → \"" + v + "\" )"
+          "( \"" + k + "\"  → \"\"\"" + v + "\"\"\" )"
         }.mkString(",")
     }
 


### PR DESCRIPTION
This PR aims to bring explicit support for `SPARK_HOME` to fetch the defaults values.

Since the var env are passed to the spawned VM, this shouldn't be required -- However, I saw that defaults wouldn't be loaded if we set only `SPARK_HOME` and not `SPARK_CONF_DIR`.

This being said, this PR allows also these configuration to be pre-fetched so it'll still work when we'll spawn VM using a cluster manager like mesos for instance.

**Note**: this should allow one to use the spark notebook using a distro like cloudera without the pain to configure the spark conf thingies in the `application.conf`.

cc @vidma @meh-ninja 
