### PR TITLE
Opensource Notebook versioning based on Git

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The Spark Notebook comes with dynamic charts and most (if not all) components ca
 Dynamic and reactive components mean that you don't have write the html, js, server code just for basic use cases.
 
 
-##Quick Start
+## Quick Start
 
 Go to [Quick Start](./docs/quick_start.md) for our 5-minutes guide to get up and running with the Spark Notebook.
 
@@ -60,8 +60,10 @@ to discuss things, to get some help, or to start contributing!
 * [HTML Widgets](./docs/widgets_html.md)
 * [Visualization Widgets](./docs/widgets_viz.md)
 * [Notebook Browser](./docs/notebook_browser.md)
-* [Configuration and Metadata](./docs/metadata.md)
+* Configuration
+    * [Notebook Configuration and Metadata](./docs/metadata.md)
     * [Using Cluster Configurations](./docs/using_cluster_tab.md)
+    * [Versioned notebook storage with Git(hub)](./modules/git-notebook-provider/README.md)
 * [Running on Clusters and Clouds](./docs/clusters_clouds.md)
 * [Community](./docs/community.md)
 * Advanced Topics

--- a/app/notebook/server/NotebookManager.scala
+++ b/app/notebook/server/NotebookManager.scala
@@ -1,28 +1,41 @@
 package notebook.server
 
 import java.io._
-import java.nio.charset.{Charset, StandardCharsets}
 import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Path, Paths}
 import java.text.SimpleDateFormat
 import java.util.Date
 
-import notebook.Notebook
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+import scala.util.{Failure, Success, Try}
 import notebook.NBSerializer._
+import notebook.io.Version
+import notebook.{Notebook, Resource}
 import org.apache.commons.io.FileUtils
 import play.api.Logger
 import play.api.libs.json._
 import utils.AppUtils
 import utils.Const.UTF_8
 
-class NotebookManager(val name: String, val notebookDir: File) {
+class NotebookManager(val notebookConfig: NotebookConfig) {
+
+  val provider = notebookConfig.notebookIoProvider
+
+  val DefaultOperationTimeout = 60.seconds
+
+  val notebookDir: File = provider.root.toFile
 
   Logger.info("Notebook directory is: " + notebookDir.getCanonicalPath)
 
   private lazy val config = AppUtils.notebookConfig
   val viewer = config.viewer
 
-
   val extension = ".snb"
+
+  val name = notebookConfig.projectName // TODO: Whatever uses this name, should be using config.projectName directly, for sure...
 
   def forbidInViewer[T](block: => T): T = {
     if (!viewer){
@@ -41,7 +54,7 @@ class NotebookManager(val name: String, val notebookDir: File) {
     nbFile
   }
 
-  def incrementFileName(base: String) = {
+  def incrementFileName(base: String): String = {
     Logger.info("Incremented Notebook at " + base)
     val newPath: String = Stream.from(1).map(base + _ + extension).dropWhile { fn =>
       val snb = notebookFile(fn)
@@ -63,11 +76,11 @@ class NotebookManager(val name: String, val notebookDir: File) {
     customImports: Option[List[String]] = None,
     customArgs: Option[List[String]] = None,
     customSparkConf: Option[JsObject] = None,
-    name:Option[String] = None) = forbidInViewer {
+    name:Option[String] = None): String = forbidInViewer {
     val sep = if (path.last == '/') "" else "/"
     val fpath = name.map(path + sep + _ + extension).getOrElse(incrementFileName(path + sep + "Untitled"))
     val nb = Notebook(
-      Some(Metadata(
+      metadata = Some(new Metadata(
         id = Notebook.getNewUUID,
         name = getName(fpath),
         customLocalRepo = customLocalRepo,
@@ -85,82 +98,111 @@ class NotebookManager(val name: String, val notebookDir: File) {
     fpath
   }
 
-  def copyNotebook(nbPath: String) = forbidInViewer {
-    getNotebook(nbPath).map { case (_, _, nbData, nbFilePath) =>
-      val newPath = incrementFileName(nbFilePath.dropRight(extension.length))
+  def copyNotebook(nbPath: String): String = forbidInViewer {
+    val nbData = getNotebook(nbPath)
+    nbData.map { nb =>
+      val newPath = incrementFileName(nb.path.dropRight(extension.length))
       val newName = getName(newPath)
-      Notebook.deserialize(nbData) match {
-        case Some(oldNB) =>
-          val newMeta = oldNB.metadata.map(_.copy(id = Notebook.getNewUUID, name = newName))
-            .orElse(Some(Metadata(id = Notebook.getNewUUID, name = newName)))
-          save(newPath, Notebook(newMeta, oldNB.cells, oldNB.worksheets, oldNB.autosaved, None), false)
-          newPath
-        case None =>
-          newNotebook()
+      val readExistingAndSaveNewNb: Future[String] = Notebook.deserializeFuture(nb.data).map { oldNB =>
+        val newNb = Notebook(oldNB.metadata.map(_.copy(id = Notebook.getNewUUID, name = newName)), oldNB.cells, oldNB.worksheets, oldNB.autosaved, None)
+        save(newPath,newNb, overwrite = false)
+        newPath
       }
+      Await.result(readExistingAndSaveNewNb, DefaultOperationTimeout)
     } getOrElse newNotebook()
+  }
+
+  def listResources(path: String): List[Resource] = {
+    Logger.info(s"listNotebooks at path $path")
+    Await.result(provider.list(absolutePath(path)), DefaultOperationTimeout)
+  }
+
+  /**
+    * Creates a new directory with name "name" under the provided path relative to this server's root directory
+    *
+    * @param parent the relative path that will be parent to the new directory
+    * @param name the name of the new directory
+    * @return a string representing the new path relative to the parent
+    */
+  def mkDir(parent:String, name:String): Try[String] = {
+    val base = new File(notebookDir, parent)
+    val newDir = new File(base, name)
+    if (newDir.mkdirs()) {
+      Success(newDir.getAbsolutePath.diff(base.getAbsolutePath))
+    } else {
+        Failure(new DirectoryCreationException(newDir))
+    }
   }
 
   def getNotebook(path: String) = {
     Logger.info(s"getNotebook at path $path")
     for (notebook <- load(path)) yield {
       val data = FileUtils.readFileToString(notebookFile(path), "UTF-8")
-      val df = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss z'('Z')'")
-      val last_mtime = df.format(new Date(notebookFile(path).lastModified()))
-      (last_mtime, notebook.name, data, path)
+      val lastModified = NotebookInfo.formatTimestamp(new Date(notebookFile(path).lastModified()))
+      NotebookInfo(lastModified, notebook.name, data, path)
     }
   }
 
-  def deleteNotebook(path: String) = forbidInViewer {
+  def deleteNotebook(path: String): Future[Notebook] = forbidInViewer {
     Logger.info(s"deleteNotebook at path $path")
-    val file = notebookFile(path)
-    if (file.exists()) {
-      file.delete()
-    }
+    provider.delete(absolutePath(path))
   }
 
-  def rename(path: String, newpath: String) = forbidInViewer {
-    Logger.info(s"rename from path $path to $newpath")
-    val newname = getName(newpath)
-    val oldfile = notebookFile(path)
-    Logger.debug(s"rename from path $path to $newpath: old file is ${oldfile.getAbsolutePath}")
-    load(path).foreach { notebook =>
-      val nb = if (notebook.name != newname) {
-        val meta = notebook.metadata.map(_.copy(name = newname))
-          .orElse(Some(Metadata(id = Notebook.getNewUUID, name = newname)))
-        notebook.copy(metadata = meta)
-      } else {
-        notebook
-      }
-      val newfile = notebookFile(newpath)
-      Logger.debug(s"rename from path $path to $newpath: new file is ${newfile.getAbsolutePath}")
-      oldfile.renameTo(newfile)
-      FileUtils.writeStringToFile(newfile, Notebook.serialize(nb))
-    }
-    (newname, newpath)
+  def rename(srcPath: String, destPath: String): (String, String) = forbidInViewer {
+    Logger.info(s"rename from path $srcPath to $destPath")
+    val newname = getName(destPath)
+    val src = absolutePath(srcPath)
+    val dest = absolutePath(destPath)
+    val resPath = Await.result(provider.move(src, dest), DefaultOperationTimeout)
+    (newname, destPath)
   }
 
-  def save(path: String, notebook: Notebook, overwrite: Boolean) = forbidInViewer {
-    Logger.info(s"save at path $path")
+  def save(path: String, notebook: Notebook, overwrite: Boolean, message: Option[String]= None): (String, String) = forbidInViewer {
+    Logger.info(s"save at path $path with message $message")
     val file = notebookFile(path)
     if (!overwrite && file.exists()) {
-      throw new NotebookExistsException("Notebook " + path + " already exists.")
+      throw new NotebookExistsException(s"Notebook [$path] already exists.")
     }
-    FileUtils.writeStringToFile(file, Notebook.serialize(notebook), "UTF-8")
-    val nb = load(path)
-    (nb.get.metadata.get.name, path)
+    // TODO: this is expected to be sync, and the implementation is ugly...
+
+    // TODO: either `provider.save` takes an extra message parameter which changes its behavior for git (commit)
+    // or we have a dedicated function like `checkpoint` or `commit` for that purpose and `save` is just saving the file
+    val savedNb: Notebook = Await.result(provider.save(Paths.get(file.toURI), notebook, message), DefaultOperationTimeout)
+    (savedNb.metadata.get.name, path)
+  }
+
+  def checkpoints(path: String): List[Version] = {
+    Await.result(provider.versions(absolutePath(path)), DefaultOperationTimeout)
+  }
+
+  def restoreCheckpoint(path:String, id:String): Option[(String, String, String)] = {
+    val notebookCheckpoint =  provider.get(absolutePath(path), Some(Version(id,"", 1L))).map{ nb =>
+      val lastModifiedTime: String = NotebookInfo.formatTimestamp(nb.metadata.get.user_save_timestamp)
+      Some((lastModifiedTime , nb.name, path))
+    }
+    Await.result(notebookCheckpoint, DefaultOperationTimeout)
   }
 
   def load(path: String): Option[Notebook] = {
     Logger.info(s"Loading notebook at path $path")
-    val file = notebookFile(path)
-    if (file.exists())
-      Notebook.deserialize(FileUtils.readFileToString(file))
-    else
-      None
+    // TODO: this is expected to be sync, and the implementation is ugly...
+    val notebook: Future[Option[Notebook]] = provider.get(absolutePath(path)).map(Option.apply)
+    Await.result(notebook, DefaultOperationTimeout)
+      .orElse(None)
   }
 
+  protected def absolutePath(path: String): Path = {
+    Paths.get(notebookFile(path).toURI)
+  }
 
 }
 
 class NotebookExistsException(message: String) extends IOException(message)
+class DirectoryCreationException(path: File) extends Exception("Could not create dir at: " + path.getCanonicalPath)
+
+case class NotebookInfo(lastModified: String, name: String, data: String, path: String)
+object NotebookInfo {
+  val dateTimeFormat = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss z'('Z')'")
+
+  def formatTimestamp(timestamp: Date): String = dateTimeFormat.format(timestamp)
+}

--- a/app/notebook/server/NotebookManager.scala
+++ b/app/notebook/server/NotebookManager.scala
@@ -138,7 +138,7 @@ class NotebookManager(val notebookConfig: NotebookConfig) {
     Logger.info(s"getNotebook at path $path")
     for (notebook <- load(path)) yield {
       val data = FileUtils.readFileToString(notebookFile(path), "UTF-8")
-      val lastModified = NotebookInfo.formatTimestamp(new Date(notebookFile(path).lastModified()))
+      val lastModified = NotebookInfo.formatTimestamp(notebookFile(path).lastModified())
       NotebookInfo(lastModified, notebook.name, data, path)
     }
   }
@@ -201,8 +201,13 @@ class NotebookExistsException(message: String) extends IOException(message)
 class DirectoryCreationException(path: File) extends Exception("Could not create dir at: " + path.getCanonicalPath)
 
 case class NotebookInfo(lastModified: String, name: String, data: String, path: String)
-object NotebookInfo {
-  val dateTimeFormat = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss z'('Z')'")
 
-  def formatTimestamp(timestamp: Date): String = dateTimeFormat.format(timestamp)
+object NotebookInfo {
+  def formatTimestamp(timestamp: Date): String = {
+    new SimpleDateFormat("dd-MM-yyyy HH:mm:ss z'('Z')'").format(timestamp)
+  }
+
+  def formatTimestamp(timestampMillis: Long): String = {
+    formatTimestamp(new Date(timestampMillis))
+  }
 }

--- a/app/utils/AppUtils.scala
+++ b/app/utils/AppUtils.scala
@@ -20,6 +20,8 @@ object AppUtils {
     play.api.Play.classloader // todo more detail, this resolves the Play classloader problems w/ remoting
   )
 
+  def isVersioningSupported = notebookManager.provider.isVersioningSupported
+
   object proxy {
     def proxyKeys(pre: String) = List(
       "_proxy",

--- a/app/utils/AppUtils.scala
+++ b/app/utils/AppUtils.scala
@@ -3,16 +3,17 @@ package utils
 import akka.actor._
 import notebook.server._
 
+import ConfigurationUtils._
+
 object AppUtils {
 
   import play.api.Play.current
 
   lazy val baseConfig = current.configuration
-
-  lazy val notebookConfig = NotebookConfig(baseConfig.getConfig("manager").get)
-  lazy val notebookManager = new NotebookManager(notebookConfig.projectName, notebookConfig.notebooksDir)
-  lazy val clustersConf = notebookConfig.config.getConfig("clusters").get
-  lazy val nbServerConf = baseConfig.getConfig("notebook-server").get.underlying
+  lazy val notebookConfig = NotebookConfig(baseConfig.getMandatoryConfig("manager"))
+  lazy val notebookManager = new NotebookManager(notebookConfig)
+  lazy val clustersConf = baseConfig.getMandatoryConfig("clusters")
+  lazy val nbServerConf = baseConfig.getMandatoryConfig("notebook-server").underlying
   lazy val kernelSystem = ActorSystem(
     "NotebookServer",
     nbServerConf,

--- a/app/utils/ConfigurationUtils.scala
+++ b/app/utils/ConfigurationUtils.scala
@@ -1,0 +1,27 @@
+package utils
+
+import notebook.io.ConfigurationMissingException
+import play.api.Configuration
+
+import scala.util.{Failure, Success, Try}
+
+
+object ConfigurationUtils {
+
+  implicit class ConfigurationOps(val baseConfiguration:Configuration) extends AnyVal {
+
+    def tryGetString(key: String) : Try[String] = {
+      baseConfiguration.getString(key).map(Success(_)).getOrElse(Failure(new ConfigurationMissingException(key)))
+    }
+
+    def getMandatoryConfig(key: String) : Configuration = {
+      tryGetConfig(key).get
+    }
+
+    def tryGetConfig(key: String) : Try[Configuration] = {
+      baseConfiguration.getConfig(key).map(Success(_)).getOrElse(Failure(new ConfigurationMissingException(key)))
+    }
+
+  }
+
+}

--- a/app/views/default.scala.html
+++ b/app/views/default.scala.html
@@ -77,6 +77,7 @@
           observable: '@routes.Assets.at("javascripts/notebook/observable")',
           equiv: '@routes.Assets.at("javascripts/notebook/equiv")',
           chat: '@routes.Assets.at("javascripts/notebook/chat")',
+          checkpoints: '@routes.Assets.at("javascripts/notebook/checkpoints")',
           job_progress: '@routes.Assets.at("javascripts/notebook/job_progress")',
           sidebar: '@routes.Assets.at("javascripts/notebook/sidebar")',
           //'jwerty.js': '@routes.Assets.at("javascripts/third/jwerty.js")'

--- a/app/views/notebook.scala.html
+++ b/app/views/notebook.scala.html
@@ -302,7 +302,9 @@
                 <ul class="nav nav-tabs" style="padding-top: 5px">
                     <li class="active"><a data-toggle="tab" href="#defined-terms">Vars <span id="defined-terms-count" class="badge"></span></a></li>
                     <li><a data-toggle="tab" href="#error-logs">Errors <span id="errors-count" class="badge"></span></a></li>
-                    <li><a data-toggle="tab" href="#browse-checkpoints">Versions</a></li>
+                    @if(_root_.utils.AppUtils.isVersioningSupported) {
+                      <li><a data-toggle="tab" href="#browse-checkpoints">Edit history</a></li>
+                    }
                 </ul>
 
                 <div class="tab-content">
@@ -323,9 +325,11 @@
                         <ul id="logsPanel" style="overflow: auto;"></ul>
                     </div>
 
-                    <div id="browse-checkpoints" class="tab-pane fade">
-                        @notebookviews.browseCheckpoints()
-                    </div>
+                    @if(_root_.utils.AppUtils.isVersioningSupported) {
+                      <div id="browse-checkpoints" class="tab-pane fade">
+                      @notebookviews.browseCheckpoints()
+                      </div>
+                    }
 
                         <div id="chat-room" style="visibility: hidden; display: none">
                             <h4>Chat Room</h4>

--- a/app/views/notebook.scala.html
+++ b/app/views/notebook.scala.html
@@ -70,10 +70,10 @@
                             title="Open a copy of this notebook's contents and start a new kernel">
                             <a href="#">Make a Copy...</a></li>
                         <li id="rename_notebook"><a href="#">Rename/move...</a></li>
-                        <li id="save_checkpoint"><a href="#">Save the file</a></li>
-                        <!--
-                        <hr/>
+
                         <li class="divider"></li>
+                        <li id="checkpoint_notebook"><a href="#">Save</a></li>
+                        <li id="save_checkpoint"><a href="#">Save (with commit message)</a></li>
                         <li id="restore_checkpoint" class="dropdown-submenu"><a href="#">Revert to Checkpoint</a>
                           <ul class="dropdown-menu">
                             <li><a href="#"></a></li>
@@ -83,8 +83,6 @@
                             <li><a href="#"></a></li>
                           </ul>
                         </li>
-                        -->
-
                         <li class="divider"></li>
 
                         <!-- <li id="print_preview"><a href="#">Print Preview</a></li> -->
@@ -304,6 +302,7 @@
                 <ul class="nav nav-tabs" style="padding-top: 5px">
                     <li class="active"><a data-toggle="tab" href="#defined-terms">Vars <span id="defined-terms-count" class="badge"></span></a></li>
                     <li><a data-toggle="tab" href="#error-logs">Errors <span id="errors-count" class="badge"></span></a></li>
+                    <li><a data-toggle="tab" href="#browse-checkpoints">Versions</a></li>
                 </ul>
 
                 <div class="tab-content">
@@ -322,6 +321,10 @@
                         * see browser console for more logs
 
                         <ul id="logsPanel" style="overflow: auto;"></ul>
+                    </div>
+
+                    <div id="browse-checkpoints" class="tab-pane fade">
+                        @notebookviews.browseCheckpoints()
                     </div>
 
                         <div id="chat-room" style="visibility: hidden; display: none">

--- a/app/views/notebookviews/browseCheckpoints.scala.html
+++ b/app/views/notebookviews/browseCheckpoints.scala.html
@@ -1,6 +1,5 @@
 <div id="checkpoints-ui">
-    <h4>Browse all versions</h4>
-    <input type="text" name="query" class="form-control" data-bind="value: checkpoints.query, hasFocus: checkpoints.isTyping" placeholder="Search in history..."/>
+    <input type="text" name="query" class="form-control" data-bind="value: checkpoints.query, hasFocus: checkpoints.isTyping" placeholder="Filter revisions..."/>
     <div class="checkpoints-result">
         <ul class="checkpoints" style="list-style:none; overflow: auto; height: 300px;" data-bind="foreach: checkpoints.renderedCheckpoints">
             <li class="result"><button class="btn btn-default btn-xs" data-bind="click: restore"><i class="fa fa-flag"></i></button> <span data-bind="text: message, attr:{ title: new Date(last_modified) }"></span></li>

--- a/app/views/notebookviews/browseCheckpoints.scala.html
+++ b/app/views/notebookviews/browseCheckpoints.scala.html
@@ -1,0 +1,9 @@
+<div id="checkpoints-ui">
+    <h4>Browse all versions</h4>
+    <input type="text" name="query" class="form-control" data-bind="value: checkpoints.query, hasFocus: checkpoints.isTyping" placeholder="Search in history..."/>
+    <div class="checkpoints-result">
+        <ul class="checkpoints" style="list-style:none; overflow: auto; height: 300px;" data-bind="foreach: checkpoints.renderedCheckpoints">
+            <li class="result"><button class="btn btn-default btn-xs" data-bind="click: restore"><i class="fa fa-flag"></i></button> <span data-bind="text: message, attr:{ title: new Date(last_modified) }"></span></li>
+        </ul>
+    </div>
+</div>

--- a/build.sbt
+++ b/build.sbt
@@ -243,7 +243,7 @@ lazy val sparkNotebook = project.in(file(".")).enablePlugins(play.PlayScala).ena
   .settings(sharedSettings: _*)
   .settings(
     bashScriptExtraDefines <+= (organization, version, scalaBinaryVersion, scalaVersion, sparkVersion, hadoopVersion, withHive) map { (org, v, sbv, sv, pv, hv, wh) =>
-      s"""export ADD_JARS="$${ADD_JARS},$${lib_dir}/$$(ls $${lib_dir} | ${org}.common | head)""""
+      s"""export ADD_JARS="$${ADD_JARS},$${lib_dir}/$$(ls $${lib_dir} | grep ${org}.common | head)""""
     },
     // configure the "universal" distribution package (i.e. spark-notebook.zip)
     mappings in Universal ++= directory("notebooks"),

--- a/build.sbt
+++ b/build.sbt
@@ -231,9 +231,21 @@ lazy val sparkNotebookCore = Project(id = "spark-notebook-core", base = file("mo
     Extra.sparkNotebookCoreSettings
   )
 
+lazy val gitNotebookProvider = Project(id = "git-notebook-provider", base = file("modules/git-notebook-provider"))
+  .settings(
+    scalaVersion := defaultScalaVersion,
+    organization := "guru.data-fellas",
+    version := version.value,
+    publishMavenStyle := true
+  )
+  .dependsOn(sparkNotebookCore)
+  .settings(
+    Extra.gitNotebookProviderSettings
+  )
+
 lazy val sparkNotebook = project.in(file(".")).enablePlugins(play.PlayScala).enablePlugins(SbtWeb)
-  .aggregate(sparkNotebookCore, sbtDependencyManager, subprocess, observable, common, spark, kernel)
-  .dependsOn(sparkNotebookCore, subprocess, observable, common, spark, kernel)
+  .aggregate(sparkNotebookCore, gitNotebookProvider, sbtDependencyManager, subprocess, observable, common, spark, kernel)
+  .dependsOn(sparkNotebookCore, gitNotebookProvider, subprocess, observable, common, spark, kernel)
   .settings(sharedSettings: _*)
   .settings(
     bashScriptExtraDefines <+= (version, scalaBinaryVersion, scalaVersion, sparkVersion, hadoopVersion, withHive) map { (v, sbv, sv, pv, hv, wh) =>

--- a/conf/application-git-storage.conf
+++ b/conf/application-git-storage.conf
@@ -20,7 +20,7 @@ manager {
     authentication.password = ${?SN_NOTEBOOKS_GIT_TOKEN}
 
     // SSH auth:
-    //    remote = "ssh://github.com/user/repo.git"
+    //    remote = "ssh://git@github.com/user/repo.git"
     //    authentication.key_file = "/Users/someuser/.ssh/id_rsa"
     //    authentication.key_file_passphrase = "somepass"
   }

--- a/conf/application-git-storage.conf
+++ b/conf/application-git-storage.conf
@@ -1,0 +1,27 @@
+include "application.conf"
+
+manager {
+  # Config for Git stored notebooks
+  notebooks {
+    # Default Config uses FileSystemNotebookProviderConfigurator
+    # Configure a local dir where store the cloned git repo
+    dir = ${?NOTEBOOKS_DIR}
+    io.provider = "notebook.io.GitNotebookProviderConfigurator"
+    io.provider_timeout = 89 seconds
+  }
+  notebook.io.GitNotebookProviderConfigurator {
+    local_path = ${manager.notebooks.dir}
+
+    // HTTPS auth
+    // remote = "https://github.com/vidma/snb-tests.git"
+    remote = ${?SN_NOTEBOOKS_GIT_HTTPS_REPO}
+    authentication.username = ${?SN_NOTEBOOKS_GIT_USER}
+    // you can use a github token as password too
+    authentication.password = ${?SN_NOTEBOOKS_GIT_TOKEN}
+
+    // SSH auth:
+    //    remote = "ssh://github.com/user/repo.git"
+    //    authentication.key_file = "/Users/someuser/.ssh/id_rsa"
+    //    authentication.key_file_passphrase = "somepass"
+  }
+}

--- a/conf/application-git-storage.conf
+++ b/conf/application-git-storage.conf
@@ -21,6 +21,7 @@ manager {
 
     // SSH auth:
     //    remote = "ssh://git@github.com/user/repo.git"
+    //    remote = "git@github.com:user/repo.git"
     //    authentication.key_file = "/Users/someuser/.ssh/id_rsa"
     //    authentication.key_file_passphrase = "somepass"
   }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -54,6 +54,18 @@ manager {
     dir = ./notebooks
     dir = ${?NOTEBOOKS_DIR}
 
+  }
+
+  # Configure notebook storage provider
+  # Default is FileSystem provider
+  # See conf/application-git-storage.conf for storing notebooks in git repository
+  notebooks.io.provider = "notebook.io.FileSystemNotebookProviderConfigurator"
+  notebooks.io.provider_timeout = 89 seconds
+  notebook.io.FileSystemNotebookProviderConfigurator {
+    notebooks.dir = ${manager.notebooks.dir}
+  }
+
+  notebooks {
     ###
     # Default custom configuration for all **CREATED** notebooks
     #
@@ -239,4 +251,8 @@ remote-repos {
     # "password" = ...,
     # "nonProxyHosts" = ...
   }
+}
+
+clusters {
+
 }

--- a/conf/routes
+++ b/conf/routes
@@ -26,6 +26,7 @@ GET            /api/contents                             controllers.Application
 GET            /api/contents/                            controllers.Application.contents(type:String, path:String="/")
 GET            /api/contents/*snb/checkpoints            controllers.Application.listCheckpoints(snb:String)
 POST           /api/contents/*snb/checkpoints            controllers.Application.saveCheckpoint(snb:String)
+POST           /api/contents/*snb/checkpoints/:id        controllers.Application.restoreCheckpoint(snb:String, id:String)
 POST           /api/contents                             controllers.Application.newContent(path:String="/")
 POST           /api/contents/                            controllers.Application.newContent(path:String="/")
 GET            /api/contents/*path                       controllers.Application.contents(type:String, path:String)

--- a/docs/using_git.md
+++ b/docs/using_git.md
@@ -1,0 +1,87 @@
+# Documentation
+
+## Git integration
+
+The Spark Notebook has support for GIT version control.
+
+In this document we will cover the [usage](#usage) and [configuration](#configuration) aspects of GIT support.
+
+
+### Usage
+
+#### Maintaining versions of your work
+
+When GIT support is enabled, the `checkpoint` function allows the user to provide a descriptive name to the current notebook. This creates a _commit_ in GIT terminology using the given message as description. 
+This _commit_ can be used at a later stage to restore a notebook to a previous state.
+
+![Checkpoint message](../images/enterprise/checkpoint-message-highlighted.png)
+
+In addition to manual commits, the Spark Notebook also has an automatic snapshot function that will create intermediate versions of the notebook at regular time intervals. These automatic versions can be used when work gets lost for unexpected reasons or when one would like to visit a previous version but did not create a manual commit of it.
+
+Automatic checkpoints always have the same message "Saved file &lt;notebook-name&gt;". 
+(At the moment of writing, the save interval time cannot be changed, but that will be addressed in a future version of the Spark Notebook.)
+
+#### Restoring a previously saved version
+
+There are two options to restore a previous version of the Spark Notebook:
+* The _Revert Checkpoint_ menu entry: It lists the lastest saved checkpoints. Clicking on an entry will restore the notebook to that corresponding version. 
+
+  ![Revert checkpoint menu](../images/enterprise/revert-checkpoint-menu.png)
+
+* Versions side bar: If the side-bar is visible, the versions box can be used to search and restore a given version. The search function will use keywords to retrieve matching candidates. If no search is provided, all versions, in reverse chronological order, will be presented.  Clicking on an entry will restore the notebook to that corresponding version.
+
+  ![Versions side bar](../images/enterprise/versions-side-bar.png)
+
+Notes:
+* When restoring a previous version, the current state of the Notebook will be replaced. Any unsaved work will be lost.
+* Saving or checkpointing the restored version will 'promote' it as the current version.
+* Restored versions will be saved by the automatic saving function, and hence promoting it to 'latest'. Therefore, restored versions can only be explored for a limited amount of time before they are persisted.
+
+#### Deleting a Notebook
+
+The 'delete' button will delete a notebook from the current state of version control. A current limitation is that deleted Notebooks cannot be restored from a previous version.
+
+
+### Configuration
+
+GIT support is enabled by using the `notebook.io.GitNotebookProviderConfigurator` to the configuration entry `manager.notebooks.io.provider`:
+
+```javascript
+manager {
+  notebooks {
+    io.provider = "notebook.io.GitNotebookProviderConfigurator"
+    ...
+  }
+}
+```
+
+This Notebook provider takes the GIT configuration in a separate stanza:
+
+```javascript
+notebook.io.GitNotebookProviderConfigurator {
+   
+    local_path = ${manager.notebooks.dir}
+    
+    # remote = "ssh://github.com/spark-notebook/unit-test-repo.git"
+    # authentication.key_file = "${HOME}/.ssh/id_rsa"
+    # remote = "http://gitblit-node:8008/r/bigdata.git"
+    # authentication {
+    #     username: "user",
+    #     password: "password"
+   }
+  }
+```
+If no remote configuration is provided, a local GIT repository will be initialized and used to store the notebooks.
+By providing a valid remote and corresponding credentials, the versions of the notebooks will be pushed to said repository.
+
+SSH and HTTPS credentials are supported and are mutually exclusive, meaning that the configuration should contain either an SSH remote URL and the corresponding `autentication.key_file` xor a HTTPS remote URL and the corresponding `authentication.username` and `authentication.password` credentials.
+
+You can use a Github token in `authentication.password`.
+
+### Known issues
+
+Have in mind that Git support is still experiemental.
+
+- if you provided wrong Git configuration, you need to **remove the local git** directory (`NOTEBOOKS_DIR`), and **restart the spark-notebook**
+- the local git directory is assumed to be either not existent, or a correctly set-up git dir
+- At the moment, SSH auth do not seem to work with a password protected key_file

--- a/modules/core/src/main/scala/notebook/Resource.scala
+++ b/modules/core/src/main/scala/notebook/Resource.scala
@@ -1,0 +1,10 @@
+package notebook
+
+sealed trait Resource {
+  def name:String
+  def path:String
+}
+
+case class GenericFile(name:String, path:String, tpe:String) extends Resource
+case class Repository(name:String, path:String) extends Resource
+case class NotebookResource(name:String, path:String) extends Resource

--- a/modules/core/src/main/scala/notebook/io/Configurable.scala
+++ b/modules/core/src/main/scala/notebook/io/Configurable.scala
@@ -1,0 +1,17 @@
+package notebook.io
+
+import com.typesafe.config.{Config, ConfigFactory}
+
+import scala.concurrent.{ExecutionContext, Future}
+import notebook.util.Logging
+
+trait Configurable[T] {
+  def apply(config: Config = ConfigFactory.empty())(implicit ec:ExecutionContext) : Future[T]
+}
+
+class ConfigurationMissingException(val key: String) extends Exception(s"Key missing: [$key]") with Logging {
+  // the 'key' value is oftentime lost (then this causes other exception), let's at least print it
+  logWarn(s"ConfigurationMissingException: key missing: $key")
+}
+
+class ConfigurationCorruptException(msg: String) extends Exception(msg)

--- a/modules/core/src/main/scala/notebook/io/FileSystemNotebookProviderConfigurator.scala
+++ b/modules/core/src/main/scala/notebook/io/FileSystemNotebookProviderConfigurator.scala
@@ -24,6 +24,7 @@ class FileSystemNotebookProviderConfigurator extends Configurable[NotebookProvid
   }
 
   private[FileSystemNotebookProviderConfigurator] class FileSystemNotebookProvider(override val root: Path) extends NotebookProvider {
+    override def isVersioningSupported: Boolean = false
 
     override def delete(path: Path)(implicit ev: ExecutionContext): Future[Notebook] = {
       get(path).flatMap { notebook =>

--- a/modules/core/src/main/scala/notebook/io/FileSystemNotebookProviderConfigurator.scala
+++ b/modules/core/src/main/scala/notebook/io/FileSystemNotebookProviderConfigurator.scala
@@ -1,0 +1,69 @@
+package notebook.io
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path, Paths}
+
+import com.typesafe.config.Config
+import notebook.{Notebook, NotebookNotFoundException}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
+
+class FileSystemNotebookProviderConfigurator extends Configurable[NotebookProvider] {
+
+  import FileSystemNotebookProviderConfigurator._
+
+  override def apply(config: Config)(implicit ec:ExecutionContext): Future[NotebookProvider] = {
+    val rootPath = Future {
+      Paths.get(config.getString(NotebooksDir))
+    }.recoverWith{ case t: Throwable =>
+      Future.failed(new ConfigurationMissingException(NotebooksDir))
+    }
+
+    rootPath.map(new FileSystemNotebookProvider(_))
+  }
+
+  private[FileSystemNotebookProviderConfigurator] class FileSystemNotebookProvider(override val root: Path) extends NotebookProvider {
+
+    override def delete(path: Path)(implicit ev: ExecutionContext): Future[Notebook] = {
+      get(path).flatMap { notebook =>
+        val res: Future[Unit] = try {
+          val deleted = Files.deleteIfExists(path)
+          if (!deleted) {
+            Future.failed(new NotebookNotFoundException(path.toString))
+          } else {
+            Future.successful(())
+          }
+        } catch {
+          case ex: Throwable => Future.failed(ex)
+        }
+        res.map(_ => notebook)
+      }
+    }
+
+    override def get(path: Path, version: Option[Version] = None)(implicit ev: ExecutionContext): Future[Notebook] = {
+      Future{Files.readAllBytes(path)}.flatMap { bytes =>
+        Notebook.deserializeFuture(new String(bytes, StandardCharsets.UTF_8))
+      }
+    }
+
+    override def save(path: Path, notebook: Notebook, saveSpec:Option[String] = None)(implicit ev: ExecutionContext): Future[Notebook] = {
+      Notebook.serializeFuture(notebook).map { nb =>
+          Files.write(path, nb.getBytes(StandardCharsets.UTF_8))
+      }.map(_ => notebook)
+    }
+
+    // Moves the notebook at src Path to the dest Path
+    override def moveInternal(src: Path, dest: Path)(implicit ev: ExecutionContext): Future[Path] = Future {
+      require(src.toFile.exists(), s"Notebook source at [$src] should exist")
+      require(dest.getParent.toFile.exists(), s"Directory at [${dest.getParent}] should exist")
+      require(!dest.toFile.exists(), s"Notebook dest at [$dest] should not exist")
+      Files.move(src, dest)
+      dest
+    }
+
+  }
+}
+object FileSystemNotebookProviderConfigurator {
+  val NotebooksDir = "notebooks.dir"
+}

--- a/modules/core/src/main/scala/notebook/io/FutureUtil.scala
+++ b/modules/core/src/main/scala/notebook/io/FutureUtil.scala
@@ -1,0 +1,20 @@
+package notebook.io
+
+import scala.concurrent.Future
+import scala.util.{Failure, Success, Try}
+
+
+object FutureUtil {
+
+  // remove when scala.version >= 2.11
+  def tryToFuture[T](t:Try[T]):Future[T] = t match {
+    case Success(s) => Future.successful(s)
+    case Failure(f) => Future.failed(f)
+  }
+
+  implicit class TryToFutureConverter[T](t: Try[T]) {
+    def toFuture: Future[T] = {
+      tryToFuture(t)
+    }
+  }
+}

--- a/modules/core/src/main/scala/notebook/io/NotebookProvider.scala
+++ b/modules/core/src/main/scala/notebook/io/NotebookProvider.scala
@@ -14,6 +14,8 @@ trait NotebookProvider {
 
   import NotebookProvider._
 
+  def isVersioningSupported: Boolean
+
   def verifyProvider(): Future[Unit] = Future.successful(())
 
   def root: Path

--- a/modules/core/src/main/scala/notebook/io/NotebookProvider.scala
+++ b/modules/core/src/main/scala/notebook/io/NotebookProvider.scala
@@ -1,0 +1,95 @@
+package notebook.io
+
+
+import java.io.{File, FileFilter}
+import java.nio.file.{Path, Paths}
+
+import notebook.NBSerializer.Metadata
+import notebook._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{ExecutionContext, Future}
+
+trait NotebookProvider {
+
+  import NotebookProvider._
+
+  def verifyProvider(): Future[Unit] = Future.successful(())
+
+  def root: Path
+
+  def listingPolicy: File => Boolean = NotebookProvider.DefaultListingPolicy
+
+  def delete(path: Path)(implicit ev: ExecutionContext): Future[Notebook]
+
+  def get(path: Path, version: Option[Version] = None)(implicit ev: ExecutionContext): Future[Notebook]
+
+  def save(path: Path, notebook: Notebook, saveSpec: Option[String] = None)(implicit ev: ExecutionContext): Future[Notebook]
+
+  // Moves the notebook with name notebookName at src Path to the dest Path
+  final def move(src: Path, dest: Path)(implicit ev: ExecutionContext): Future[Path] = {
+    val srcName = src.getFileName.toString
+    val destName = dest.getFileName.toString
+    for {
+      moved <- moveInternal(src, dest)
+      res <- if (srcName == destName) {
+          Future.successful(dest)
+        } else {
+        renameInternal(moved, destName)
+      }
+    } yield res
+  }
+
+  // physically moves the notebook, following the logic inherent to the provider
+  def moveInternal(src:Path, dest: Path)(implicit ev: ExecutionContext): Future[Path]
+
+  // Renames the internal data of a notebook
+  final def renameInternal(path: Path, newName: String)(implicit ev: ExecutionContext): Future[Path] = {
+    val now = new java.util.Date()
+    for {
+      nb <- get(path)
+      meta = nb.metadata.map(_.copy(name = newName, user_save_timestamp = now))
+        .orElse(Some(Metadata(java.util.UUID.randomUUID.toString, newName, now, now)))
+      renamedNb = nb.updateMetadata(meta)
+      _ <- save(path, renamedNb)
+    } yield path
+  }
+
+  // retrieves available versions of the provided notebook path. To be extended by providers that support versioning.
+  def versions(path:Path)(implicit ev: ExecutionContext): Future[List[Version]] = Future.successful(Nil)
+
+  private [io] lazy val listFilter = new FileFilter() {
+    override def accept(file: File): Boolean = listingPolicy(file)
+  }
+
+  def list(path: Path)(implicit ec: ExecutionContext): Future[List[Resource]] = {
+    def relativePath(f: java.io.File): String = root.relativize(Paths.get(f.getAbsolutePath)).toString
+    Future {
+      Option(root.resolve(path).toFile.listFiles(listFilter))
+        .filter(_.length > 0) //toList fails if listFiles is empty
+        .map(_.toList)
+        .getOrElse(Nil)
+        .map(f => (f.getName,relativePath(f),f))
+        .collect {
+          case (name, relPath, file) =>
+            if (isNotebookFile(file))
+              NotebookResource(name.dropRight(".snb".length), relPath)
+            else if (file.isFile)
+              GenericFile(name, relPath, "file")
+            else
+              Repository(name, relPath)
+        }
+    }
+  }
+}
+
+case class Version (id: String, message: String, timestamp: Long)
+
+
+object NotebookProvider {
+  def isNotebookFile(f: File): Boolean = f.isFile && f.getName.endsWith(".snb")
+  def isVisibleDirectory(f: File): Boolean = f.isDirectory && !f.getName.startsWith(".")
+  def DefaultListingPolicy(f:File): Boolean = isNotebookFile(f) || isVisibleDirectory(f)
+}
+
+

--- a/modules/core/src/main/scala/notebook/io/NotebookProviderFactory.scala
+++ b/modules/core/src/main/scala/notebook/io/NotebookProviderFactory.scala
@@ -1,0 +1,32 @@
+package notebook.io
+
+import com.typesafe.config.Config
+import notebook.io.FutureUtil._
+import notebook.util.Logging
+
+import scala.concurrent.duration.{FiniteDuration, MILLISECONDS}
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.util.Try
+
+object NotebookProviderFactory extends Logging {
+  def createProviderConfigurator(providerFactoryClass: String): Configurable[NotebookProvider] = {
+    Class.forName(providerFactoryClass).newInstance().asInstanceOf[Configurable[NotebookProvider]]
+  }
+
+  def createNotebookIoProvider(providerConfiguratorClass: String, providerConfig: Config, initTimeoutMillis: Long
+                              )(implicit ec: ExecutionContext): NotebookProvider = {
+
+    val eventualProvider: Future[NotebookProvider] = Try {
+      val factory = createProviderConfigurator(providerConfiguratorClass)
+      factory(providerConfig)
+    }.toFuture
+      .flatMap(identity)
+      .recoverWith { case ex: Exception =>
+        logError(s"Unable to instantiate provider from key [$providerConfiguratorClass]. Reason: [${ex.getMessage}]")
+        Future.failed(ex)
+      }
+
+    Await.result(eventualProvider, new FiniteDuration(initTimeoutMillis, MILLISECONDS))
+  }
+
+}

--- a/modules/core/src/test/scala/notebook/io/FileSystemNotebookProviderConfiguratorTests.scala
+++ b/modules/core/src/test/scala/notebook/io/FileSystemNotebookProviderConfiguratorTests.scala
@@ -1,0 +1,53 @@
+package notebook.io
+
+import java.nio.file.{Files, Path}
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import play.api.libs.json.{JsNumber, JsObject}
+import scala.collection.JavaConverters._
+
+class FileSystemNotebookProviderConfiguratorTests extends WordSpec with Matchers with ScalaFutures with BeforeAndAfterAll {
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  var notebookDir : String = _
+  var tempDir: Path = _
+
+  override def beforeAll: Unit = {
+    tempDir = Files.createTempDirectory("file-system-notebook-provider")
+    notebookDir = tempDir.toAbsolutePath.toFile.getAbsolutePath + "/notebook"
+  }
+
+
+  "File system notebook provider configurator" should {
+
+    def instantiateProvider() = Class.forName("notebook.io.FileSystemNotebookProviderConfigurator").newInstance().asInstanceOf[Configurable[NotebookProvider]]
+
+    "be instantiable" in {
+      noException should be thrownBy (instantiateProvider)
+    }
+
+    "configure a new notebook provider" in {
+      val configurator = instantiateProvider()
+      val dirConfig = ConfigFactory.parseMap(Map("notebooks.dir" -> notebookDir).asJava)
+      val notebookProvider = configurator(dirConfig)
+      whenReady(notebookProvider) { nbp =>
+        nbp shouldBe a[NotebookProvider]
+      }
+    }
+
+    "fail when the configuration is missing" in {
+      val configurator = instantiateProvider()
+      val dirConfig = ConfigFactory.parseMap(Map("foo.bar" -> "boo").asJava)
+      val notebookProvider = configurator(dirConfig)
+      whenReady(notebookProvider.failed) { nbp =>
+        nbp shouldBe a[ConfigurationMissingException]
+        nbp.getMessage should include (FileSystemNotebookProviderConfigurator.NotebooksDir)
+      }
+    }
+
+  }
+
+}

--- a/modules/core/src/test/scala/notebook/io/FileSystemNotebookProviderTests.scala
+++ b/modules/core/src/test/scala/notebook/io/FileSystemNotebookProviderTests.scala
@@ -1,0 +1,239 @@
+package notebook.io
+
+
+import java.nio.file.{Files, Path, Paths}
+
+import com.typesafe.config.ConfigFactory
+import notebook.NBSerializer.Metadata
+import notebook.Notebook
+import org.apache.commons.io.FileUtils
+import org.joda.time.{DateTime, DateTimeZone}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Millis, Seconds, Span}
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import play.api.libs.json.{JsNumber, JsObject}
+import play.libs.Json
+
+import scala.collection.JavaConverters._
+import scala.concurrent.{Await}
+import scala.concurrent.duration._
+import scala.io.Source
+import scala.util.Try
+
+class FileSystemNotebookProviderTests extends WordSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  val DefaultWait = 2 //seconds
+  val DefaultWaitSeconds = DefaultWait seconds
+  implicit val defaultPatience =
+    PatienceConfig(timeout =  Span(DefaultWait, Seconds), interval = Span(5, Millis))
+
+  var tempPath: Path = _
+  var provider: NotebookProvider = _
+  var notebookPath: Path = _
+
+  val id = "foo-bar-loo-lar"
+  val testName = "test-notebook-name"
+  val sparkNotebook = Map("build" -> "unit-tests")
+  val customLocalRepo = Some("local-repo")
+  val customRepos = Some(List("custom-repo"))
+  val customDeps = Some(List(""""org.custom" % "dependency" % "1.0.0""""))
+  val customImports = Some(List("""import org.cusom.dependency.SomeClass"""))
+  val customArgs = Some(List.empty[String])
+  val customSparkConf = Some(JsObject( List(("spark.driverPort", JsNumber(1234))) ))
+
+  val metadata = new Metadata(
+    id =  id,
+    name = testName,
+    user_save_timestamp =  new DateTime(1999, 9, 9, 9, 9, 9,DateTimeZone.forID("CET")).toDate,
+    auto_save_timestamp =  new DateTime(2001, 1, 1, 0, 0, 0,DateTimeZone.forID("CET")).toDate,
+    sparkNotebook = Some(sparkNotebook),
+    customLocalRepo = customLocalRepo,
+    customRepos = customRepos,
+    customDeps = customDeps,
+    customImports = customImports,
+    customArgs = customArgs,
+    customSparkConf = customSparkConf)
+
+  val raw =
+    """{
+      |"metadata" : {
+      |  "id" : "foo-bar-loo-lar",
+      |  "name" : "test-notebook-name",
+      |  "user_save_timestamp" : "1999-09-09T09:09:09.000Z",
+      |  "auto_save_timestamp" : "2001-01-01T00:00:00.000Z",
+      |  "language_info" : {
+      |    "name" : "scala",
+      |    "file_extension" : "scala",
+      |    "codemirror_mode" : "text/x-scala"
+      |  },
+      |  "trusted" : true,
+      |  "sparkNotebook" : {
+      |    "build" : "unit-tests"
+      |  },
+      |  "customLocalRepo" : "local-repo",
+      |  "customRepos" : [ "custom-repo" ],
+      |  "customDeps" : [ "\"org.custom\" % \"dependency\" % \"1.0.0\"" ],
+      |  "customImports" : [ "import org.cusom.dependency.SomeClass" ],
+      |  "customArgs" : [ ],
+      |  "customSparkConf" : {
+      |    "spark.driverPort" : 1234
+      |  },
+      |  "customVars" : null
+      |},
+      |"cells" : [ ]
+      |}
+    """.stripMargin
+
+  val notebook = {
+    val nb = Notebook(metadata = Some(metadata), nbformat = None)
+    val normalizedNb = Notebook.serializeFuture(nb).flatMap(Notebook.deserializeFuture)
+    Await.result(normalizedNb, DefaultWaitSeconds)
+  }
+
+  override def beforeAll: Unit = {
+    tempPath = Files.createTempDirectory("file-system-notebook-provider")
+    notebookPath = tempPath.resolve("notebooks")
+    Files.createDirectories(notebookPath)
+
+    val dirConfig = ConfigFactory.parseMap(Map("notebooks.dir" -> notebookPath.toAbsolutePath.toString).asJava)
+    val configurator = new FileSystemNotebookProviderConfigurator()
+    provider = Await.result(configurator(dirConfig), DefaultWaitSeconds)
+  }
+
+  override def afterAll: Unit = {
+    FileUtils.deleteDirectory( tempPath.toFile )
+  }
+
+  "File system notebook provider" should {
+
+    "create a notebook file" in {
+      val nbPath = notebookPath.resolve("testNew.snb")
+      assume(!nbPath.toFile.exists())
+      whenReady( provider.save(nbPath, notebook) ) { n =>
+        nbPath.toFile.exists() should be (true)
+      }
+    }
+
+    "created content should be valid JSON" in {
+      val nbPath = notebookPath.resolve("testJson.snb")
+      whenReady( provider.save(nbPath, notebook) ) { n =>
+        val content = Source.fromFile(nbPath.toFile).mkString("")
+        Try{Json.parse(content)} should be ('success)
+      }
+    }
+
+    "load saved file" in {
+      val nbPath = notebookPath.resolve("testLoad.snb")
+      val loadedNb = for {
+        _ <- provider.save(nbPath, notebook)
+        loaded <- provider.get(nbPath)
+      } yield loaded
+
+      whenReady( loadedNb ) { nb =>
+        nb should be (notebook)
+      }
+    }
+
+    "move a notebook file to another directory" in {
+      val nbName = "testMove.snb"
+      val originalPath = notebookPath.resolve(nbName)
+      val targetDir = notebookPath.resolve(s"dest")
+      Files.createDirectories(targetDir)
+      val targetNbPath = targetDir.resolve(nbName)
+
+      val moved = for {
+        _ <- provider.save(originalPath, notebook)
+        path <- provider.move(originalPath, targetNbPath)
+        nb <- provider.get(path)
+      } yield (nb, path)
+
+      whenReady(moved) { case (nb, path) =>
+        path should be (targetNbPath)
+        originalPath.toFile.exists() should be(false)
+        path.toFile.exists() should be(true)
+        nb should be (notebook)
+      }
+    }
+
+    "rename a notebook file" in {
+      val originalPath = notebookPath.resolve("testRename.snb")
+      val newName = "renamed.snb"
+      val destPath = notebookPath.resolve(newName)
+
+      val renamedNotebook = for {
+        _ <- provider.save(originalPath, notebook)
+        newPath <- provider.move(originalPath, destPath)
+        renamedNb <- provider.get(newPath)
+      } yield renamedNb
+
+      whenReady (renamedNotebook) {nb =>
+        originalPath.toFile.exists() should be (false)
+        destPath.toFile.exists() should be (true)
+        nb.name should be (newName)
+        nb.metadata.get.name should be (newName)
+      }
+    }
+
+    "preserve the id of a renamed notebook" in {
+      val nbPath = notebookPath.resolve("testinternal-rename.snb")
+      val originalId = notebook.metadata.get.id
+      val res = for {
+        nb <- provider.save(nbPath, notebook)
+        _ <- provider.renameInternal(nbPath, "testinternal-renamed")
+        renamed <- provider.get(nbPath)
+      } yield renamed
+
+      whenReady(res) { renamedNb =>
+        renamedNb.metadata.get.id should be(originalId)
+      }
+    }
+
+    "fail to move an unexisting notebook" in {
+      whenReady( provider.move(Paths.get("/path/to/nowhere"), notebookPath).failed ) { n =>
+        n shouldBe a [java.lang.IllegalArgumentException]
+      }
+    }
+
+    "fail to move a notebook to a non-existing directory" in {
+      val nbPath = notebookPath.resolve("testMoveNonExist.snb")
+      val nonExistingPath = notebookPath.resolve("nowhere/testMoveNonExist.snb")
+      val test = for {
+        nb <- provider.save(nbPath, notebook)
+        moved <- provider.move(nbPath, nonExistingPath)
+      }  yield (moved)
+
+      whenReady( test.failed ) { failure =>
+        failure shouldBe a[java.lang.IllegalArgumentException]
+      }
+    }
+
+    "fail to load an unexisting file" in {
+      whenReady( provider.get(Paths.get("/path/to/nowhere")).failed ) { n =>
+        n shouldBe a [java.nio.file.NoSuchFileException]
+      }
+    }
+
+    "delete the file" in {
+      val nbPath = notebookPath.resolve("testDeleted.snb")
+      val deletedNb = for {
+        _ <- provider.save(nbPath,notebook)
+        deleted <- provider.delete(nbPath)
+      } yield deleted
+
+      whenReady( deletedNb ) { n =>
+        nbPath.toFile.exists() should be (false)
+      }
+    }
+
+    "fail to load deleted file" in {
+      val nbPath = notebookPath.resolve("notThere.snb")
+      whenReady( provider.get(nbPath).failed ) { n =>
+        n shouldBe a [java.nio.file.NoSuchFileException]
+      }
+    }
+
+  }
+
+}

--- a/modules/core/src/test/scala/notebook/io/NotebookProviderTests.scala
+++ b/modules/core/src/test/scala/notebook/io/NotebookProviderTests.scala
@@ -1,0 +1,166 @@
+package notebook.io
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import java.io.File
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContext.Implicits.global
+import org.apache.commons.io.FileUtils
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.prop.Tables.Table
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import notebook.{GenericFile, Notebook, NotebookResource, Repository}
+import org.scalatest.time.{Millis, Seconds, Span}
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class NotebookProviderTests extends WordSpec with Matchers with BeforeAndAfterAll with ScalaFutures with TableDrivenPropertyChecks {
+
+  implicit val defaultPatience =
+    PatienceConfig(timeout =  Span(2, Seconds), interval = Span(5, Millis))
+
+  val rootPath = Files.createTempDirectory("notebook-provider-test")
+  val notebookPath = rootPath.resolve("notebook")
+  val emptyPath = rootPath.resolve("empty")
+  val notebookFile = "nb.snb"
+  val resourceFile = "res.res"
+  val dir = "dir"
+  val hiddenDir = ".hidden"
+  val hiddenGitDir = ".git"
+  val dirPath = notebookPath.resolve(dir)
+  val hiddenPath = notebookPath.resolve(hiddenDir)
+  val hiddenGitPath = notebookPath.resolve(hiddenGitDir)
+
+  override def beforeAll(): Unit = {
+    Seq(notebookPath, emptyPath, dirPath, hiddenPath, hiddenGitPath).foreach(path => Files.createDirectory(path))
+    Seq(notebookFile, resourceFile).foreach { file =>
+      val filePath = notebookPath.resolve(file)
+      Files.write(filePath, "text".getBytes(StandardCharsets.UTF_8))
+    }
+  }
+
+  override def afterAll(): Unit = {
+    FileUtils.deleteDirectory(rootPath.toFile)
+  }
+
+  class BaseProvider extends NotebookProvider {
+    type SaveSpec = Unit
+    override def root: Path = rootPath
+    override def get(path: Path, version: Option[Version])(implicit ev: ExecutionContext): Future[Notebook] = ???
+    override def delete(path: Path)(implicit ev: ExecutionContext): Future[Notebook] = ???
+    override def save(path: Path, notebook: Notebook, saveSpec:Option[String] = None)(implicit ev: ExecutionContext): Future[Notebook] = ???
+    override def moveInternal(src: Path, dest: Path)(implicit ev: ExecutionContext): Future[Path] = ???
+  }
+
+  val T = true
+  val F = false
+
+  val providerDefault = new BaseProvider()
+
+  val providerNoFilter = new BaseProvider(){
+    override val listingPolicy = (f:File) => true
+  }
+
+  val providerExplicitFilter = new BaseProvider() {
+    override val listingPolicy = (f:File) => (f.getName endsWith ".snb") || (f.getName startsWith "res")
+  }
+
+  val providerPatternFilter = new BaseProvider() {
+    override val listingPolicy = (f:File) =>
+      if (f.isDirectory) {
+        !f.getName.startsWith(".")
+      } else {
+        f.getName.endsWith(".snb")
+    }
+  }
+
+  "Notebook provider" should {
+
+    "retrieve a list of resources from an empty path" in {
+      whenReady(providerDefault.list(emptyPath)) { files =>
+        files should be('empty)
+      }
+    }
+
+
+    "retrieve a list of resources from a path" in {
+      whenReady(providerNoFilter.list(notebookPath)) { resources =>
+        resources.size should be(5)
+        resources.foreach {
+          case nb: NotebookResource => nb.name should be(notebookFile.dropRight(".snb".size))
+          case res: GenericFile => res.name should be(resourceFile)
+          case rep: Repository => rep.name should (be(hiddenDir) or be(dir) or be(hiddenGitDir))
+          case x => fail("unexpected resource" + x)
+        }
+      }
+    }
+
+    "retrieves a list of resources using default filtering" in {
+      whenReady(providerDefault.list(notebookPath)) { resources =>
+        resources.size should be (2)
+        resources.foreach {
+          case nb: NotebookResource => nb.name should be(notebookFile.dropRight(".snb".size))
+          case rep: Repository => rep.name should be(dir)
+          case x => fail("unexpected resource" + x)
+        }
+      }
+
+    }
+  }
+
+  "Notebook provider" should {
+
+    val defaultInstance = new BaseProvider()
+
+    "retrieves a list of resources filtered with a literal" in {
+      whenReady(providerExplicitFilter.list(notebookPath)) { resources =>
+        println(" Retrieved files: " + resources.mkString(", "))
+        resources.size should be (2)
+        resources.foreach {
+          case nb: NotebookResource => nb.name should be(notebookFile.dropRight(".snb".size))
+          case res: GenericFile => res.name should be(resourceFile)
+          case x => fail("unexpected resource" + x)
+        }
+      }
+    }
+
+    "retrieves a list of resources filtered with a pattern" in {
+      whenReady(providerPatternFilter.list(notebookPath)) { resources =>
+        resources.size should be (2)
+        resources.foreach {
+          case nb: NotebookResource => nb.name should be(notebookFile.dropRight(".snb".size))
+          case rep: Repository => rep.name should be(dir)
+          case x => fail("unexpected resource" + x)
+        }
+      }
+    }
+
+  }
+
+  val filterTable = Table(
+    ("filename", "no_filter", "explicit_filter", "pattern_filter"),
+    (".git",     T, F, F),
+    ("res.res",  T, T, F),
+    ("nt.snb",   T, T, T),
+    (".file",    T, F, F)
+  )
+  val withProvider: BaseProvider => String => Boolean = provider => filename =>
+    provider.listFilter.accept(new java.io.File(s"./$filename"))
+
+  "allow filenames following the filter criteria" in {
+    val explicitFiltering = withProvider(providerExplicitFilter)
+    val noFiltering = withProvider(providerNoFilter)
+    val patternFiltering = withProvider(providerPatternFilter)
+
+    forAll(filterTable) { (filename, noFilter, explicitFilter, patternFilter) =>
+      explicitFiltering(filename) should be(explicitFilter)
+      noFiltering(filename) should be(noFilter)
+      patternFiltering(filename) should be(patternFilter)
+    }
+  }
+
+}

--- a/modules/git-notebook-provider/.gitignore
+++ b/modules/git-notebook-provider/.gitignore
@@ -1,0 +1,6 @@
+.DS_Store
+**/.idea
+target
+git-notebook-provider/target
+git-notebook-provider/project/target
+git-notebook-provider/project/project

--- a/modules/git-notebook-provider/README.md
+++ b/modules/git-notebook-provider/README.md
@@ -1,0 +1,71 @@
+# Git notebook provider
+
+Support for git backed notebook provider.
+
+## Settings
+
+- `local_path`: where the git repo is located on the local drive; no default - **required**
+- `remote`: optional, remote address, if specified, the remote will be cloned when the provider is initialized; if not given, a repo will be created at the `local_path`
+- `branch`: optional; default `master`
+- `authentication.key_file`: path to the key file; only applies to SSH
+- `authentication.key_file_passphrase`: passphrase for the key file; not required; no default
+- `authentication.username`: repository username; HTTP(S) only
+- `authentication.password`: repository password
+
+## Remotes
+
+The provider supports HTTP, HTTPS and SSH protocols. The remote URI needs to be in the following format, for SSH:
+
+    ssh://user@example.com/repo.git
+
+For HTTP / HTTPS:
+
+    http(s)://example.com/repo.git
+
+## Authentication
+
+The provider first checks for `key_file`, if none specified, it will look for the `username` and `password`. If none given, the provider assumes no authentication.  
+If `key_file` is specified but the file does not exist, the provider will fail to initialize.  
+If the `key_file` is protected with the passphrase, specify it with `key_file_passphrase` property.  
+If using HTTP(S), specify both, `username` and `password` in the `authentication` section.  
+If using `password` based SSH authentication, specify `authentication.password` only.
+
+## Pushing to remote
+
+If a `remote` is specified, all changes in the local repository will be pushed with `-f` (force) to the remote.
+
+## Using with the spark-notebook(-enterpise)
+
+In the configuration of the spark-notebook, set the following properties:
+
+    manager {
+      ...
+      notebooks {
+        ...
+        io.provider = "notebook.io.GitNotebookProvider"
+      }
+      ...
+    }
+    
+    notebook.io.GitNotebookProvider {
+      // remote ...
+      // branch ...
+      local_path = ${manager.notebooks.dir}
+      authentication {
+        key_file = "${MESOS_SANDBOX}/git.key"
+      }
+    }
+    
+Put the output JAR of this project on the class path.
+
+## Unit tests
+
+The HTTPS and SSH intergration tests are by ignored by default. The reason is that, for those to run, one has to setup GitHub credentials.  
+To run those tests, open the test suite and change it from `ignore` to `should`. Next, create a `test.user.properties` test resource file and provider your `username` and Git `password` (or token in case of GitHub). For the SSH tests, specify `key_file` and `key_file_passphrase`, if passphrase is used.  
+For example, to generate a GitHub token, go to https://github.com/settings/tokens, click on `Generate new token` button, provide token description and select `repo` and `user` scopes.  
+To verify that the test worked, run the tests, if all tests pass, go to: https://github.com/spark-notebook/unit-test-repo/commits/master, you should see two commits at the top matching the current unit test.  
+**IMPORTANT**: Do not run HTTPS and SSH tests at the same time. Run one or the other.
+
+# License
+
+Proprietary.

--- a/modules/git-notebook-provider/README.md
+++ b/modules/git-notebook-provider/README.md
@@ -18,16 +18,19 @@ The provider supports HTTP, HTTPS and SSH protocols. The remote URI needs to be 
 
     ssh://user@example.com/repo.git
 
+  P.S. For gitub use this: `ssh://git@github.com/some-github-organization/some-repo.git`
+
+
 For HTTP / HTTPS:
 
     http(s)://example.com/repo.git
 
 ## Authentication
 
-The provider first checks for `key_file`, if none specified, it will look for the `username` and `password`. If none given, the provider assumes no authentication.  
-If `key_file` is specified but the file does not exist, the provider will fail to initialize.  
-If the `key_file` is protected with the passphrase, specify it with `key_file_passphrase` property.  
-If using HTTP(S), specify both, `username` and `password` in the `authentication` section.  
+The provider first checks for `key_file`, if none specified, it will look for the `username` and `password`. If none given, the provider assumes no authentication.
+If `key_file` is specified but the file does not exist, the provider will fail to initialize.
+If the `key_file` is protected with the passphrase, specify it with `key_file_passphrase` property.
+If using HTTP(S), specify both, `username` and `password` in the `authentication` section.
 If using `password` based SSH authentication, specify `authentication.password` only.
 
 ## Pushing to remote
@@ -39,33 +42,27 @@ If a `remote` is specified, all changes in the local repository will be pushed w
 In the configuration of the spark-notebook, set the following properties:
 
     manager {
-      ...
-      notebooks {
-        ...
-        io.provider = "notebook.io.GitNotebookProvider"
-      }
+      notebooks.io.provider = "notebook.io.GitNotebookProvider"
       ...
     }
-    
+
     notebook.io.GitNotebookProvider {
-      // remote ...
-      // branch ...
+      // optional: remote = ""
+      // optional: branch = ""
       local_path = ${manager.notebooks.dir}
       authentication {
         key_file = "${MESOS_SANDBOX}/git.key"
       }
     }
-    
-Put the output JAR of this project on the class path.
 
 ## Unit tests
 
-The HTTPS and SSH intergration tests are by ignored by default. The reason is that, for those to run, one has to setup GitHub credentials.  
-To run those tests, open the test suite and change it from `ignore` to `should`. Next, create a `test.user.properties` test resource file and provider your `username` and Git `password` (or token in case of GitHub). For the SSH tests, specify `key_file` and `key_file_passphrase`, if passphrase is used.  
-For example, to generate a GitHub token, go to https://github.com/settings/tokens, click on `Generate new token` button, provide token description and select `repo` and `user` scopes.  
-To verify that the test worked, run the tests, if all tests pass, go to: https://github.com/spark-notebook/unit-test-repo/commits/master, you should see two commits at the top matching the current unit test.  
-**IMPORTANT**: Do not run HTTPS and SSH tests at the same time. Run one or the other.
+The HTTPS and SSH intergration tests are by ignored by default (as GitHub credentials are needed).
 
-# License
+To run those tests, open the `GitNotebookProviderWithCloneTests.scala` and remove the `@Ignore` tags.
+Next, see `./test-git-support.bash` script, and add make the corresponding environment variables available (you may store them to `~/.bashrc` too).
 
-Proprietary.
+For example:
+ - first generate a GitHub token (go to https://github.com/settings/tokens , click on `Generate new token` button, select `repo` and `user` scopes)
+ - run the `./test-git-support.bash`
+ - if all tests pass, you should see two new commits matching the current unit test

--- a/modules/git-notebook-provider/build.sbt
+++ b/modules/git-notebook-provider/build.sbt
@@ -1,0 +1,7 @@
+publishArtifact in Test := false
+
+libraryDependencies += "com.typesafe" % "config" % "1.2.1"
+
+libraryDependencies += "org.eclipse.jgit" % "org.eclipse.jgit" % "4.6.0.201612231935-r"
+
+libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6" % "test"

--- a/modules/git-notebook-provider/project/build.properties
+++ b/modules/git-notebook-provider/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version = 0.13.9

--- a/modules/git-notebook-provider/project/plugins.sbt
+++ b/modules/git-notebook-provider/project/plugins.sbt
@@ -1,0 +1,1 @@
+logLevel := Level.Warn

--- a/modules/git-notebook-provider/src/main/scala/notebook/io/GitNotebookProvider.scala
+++ b/modules/git-notebook-provider/src/main/scala/notebook/io/GitNotebookProvider.scala
@@ -34,6 +34,8 @@ class GitNotebookProviderConfigurator extends Configurable[NotebookProvider] {
 class ConfigurableGitNotebookProvider(val gitProvider: GitProvider, commitMsgs: CommitMessages) extends NotebookProvider {
   import GitNotebookProvider._
 
+  override def isVersioningSupported: Boolean = true
+
   override val root = gitProvider.gitContext.localPath
   def relativize(path:Path) = root.relativize(path)
 

--- a/modules/git-notebook-provider/src/main/scala/notebook/io/GitNotebookProvider.scala
+++ b/modules/git-notebook-provider/src/main/scala/notebook/io/GitNotebookProvider.scala
@@ -1,0 +1,137 @@
+package notebook.io
+
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+
+import com.typesafe.config.Config
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
+import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContext.Implicits.global
+import notebook.{Notebook, NotebookNotFoundException, Resource}
+
+object GitNotebookProvider {
+  val DefaultBranch = "master"
+  case class CommitSpec(message: String)
+}
+
+class GitNotebookProviderConfigurator extends Configurable[NotebookProvider] {
+
+  import ConfigUtils._
+  import scala.concurrent.duration._
+  val InitializationTimeout = 10 seconds
+
+  override def apply(config: Config)(implicit ec:ExecutionContext): Future[NotebookProvider] = {
+    for {
+      commitMessages <- CommitMessagesConfiguration(config)
+      gitProvider <- (new GitProviderConfigurator())(config)
+    } yield new ConfigurableGitNotebookProvider(gitProvider, commitMessages)
+  }
+}
+
+class ConfigurableGitNotebookProvider(val gitProvider: GitProvider, commitMsgs: CommitMessages) extends NotebookProvider {
+  import GitNotebookProvider._
+
+  override val root = gitProvider.gitContext.localPath
+  def relativize(path:Path) = root.relativize(path)
+
+  // refresh dir => fs.list
+  override def list(path: Path)(implicit ev: ExecutionContext): Future[List[Resource]] = {
+    gitProvider.refreshLocal().flatMap(_ => super.list(relativize(path)))
+  }
+
+  // refresh dir => fs.get file
+  override def get(path: Path, version: Option[Version] = None)(implicit ev: ExecutionContext): Future[Notebook] = {
+    val checkoutVersion = version.map{version =>
+      gitProvider.checkout(relativize(path).toString, version.id)
+    }.getOrElse{ Future.successful(())}
+    for {
+      _ <- gitProvider.refreshLocal()
+      _ <- checkoutVersion
+      notebook <- if (Files.exists(path)) {
+        Notebook.deserializeFuture(new String(Files.readAllBytes(path), StandardCharsets.UTF_8))
+      } else {
+        Future.failed(new NotebookNotFoundException(path.toString))
+      }
+    } yield notebook
+  }
+
+  // check exists => fs.delete => git.delete
+  override def delete(path: Path)(implicit ev: ExecutionContext): Future[Notebook] = {
+    val relativePathStr = relativize(path).toString
+    for {
+      notebook <- get(path)
+      _ <- {
+        val deleted = Files.deleteIfExists(path)
+        if (deleted) {
+          gitProvider.remove(relativePathStr, s"${commitMsgs.delete} $relativePathStr")
+        } else {
+          Future.failed(new NotebookNotFoundException(relativePathStr))
+        }
+      }
+      _ <- gitProvider.push()
+    } yield notebook
+  }
+
+  override def versions(path:Path)(implicit ev: ExecutionContext): Future[List[Version]] = {
+    gitProvider.versions(relativize(path).toString)
+  }
+
+  // fs.save => git.commit => git.push
+  override def save(path: Path, notebook: Notebook, saveSpec: Option[String]= None)(implicit ev: ExecutionContext): Future[Notebook] = {
+    val relativePathStr = relativize(path).toString
+    val commitMsg = saveSpec.getOrElse(s"${commitMsgs.commit} $relativePathStr")
+    for {
+      nb <- Notebook.serializeFuture(notebook)
+      _ <- Future{Files.write(path, nb.getBytes(StandardCharsets.UTF_8))}
+      _ <- gitProvider.add(relativePathStr, commitMsg)
+      _ <- gitProvider.push()
+      persistedNb <- get(path)
+    } yield persistedNb
+  }
+
+  override def moveInternal(src: Path, dest: Path)(implicit ev: ExecutionContext): Future[Path] = {
+    val relSrc = relativize(src).toString
+    val relDest = relativize(dest).toString
+    val movedPath = Future {
+      require(src.toFile.exists(), s"Notebook source at [$src] should exist")
+      require(dest.getParent.toFile.exists(), s"Directory at [${dest.getParent()}] should exist")
+      require(!dest.toFile.exists(), s"Notebook dest at [$dest] should not exist")
+      Files.move(src, dest)
+      dest
+    }
+    for {
+      _ <- movedPath
+      _ <- gitProvider.add(relDest, commitMsgs.move)
+      _ <- gitProvider.remove(relSrc, commitMsgs.move)
+    } yield dest
+  }
+}
+
+object ConfigUtils {
+
+  implicit class ConfigOps(val config:Config) extends AnyRef {
+
+    def tryGetString(path: String) : Try[String] = {
+      if (config.hasPath(path)) {
+        Success(config.getString(path))
+      } else {
+        Failure(new ConfigurationMissingException(path))
+      }
+    }
+
+    def getMandatoryString(path: String) : String = tryGetString(path).get
+
+    def getSafeString(path:String) : Option[String] = tryGetString(path).toOption
+
+    def getSafeList(path:String) : Option[List[String]] = {
+      if (config.hasPath(path))
+        Some(config.getStringList(path).asScala.toList)
+      else
+        None
+    }
+  }
+
+}

--- a/modules/git-notebook-provider/src/main/scala/notebook/io/GitProvider.scala
+++ b/modules/git-notebook-provider/src/main/scala/notebook/io/GitProvider.scala
@@ -1,0 +1,345 @@
+package notebook.io
+
+import java.io.File
+import java.net.URI
+import java.nio.file.{Files, Path}
+
+import com.jcraft.jsch.Session
+import com.typesafe.config.Config
+import org.eclipse.jgit.api.{CloneCommand, Git, TransportCommand, TransportConfigCallback}
+import org.eclipse.jgit.lib.Repository
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder
+import org.eclipse.jgit.transport.OpenSshConfig.Host
+import org.eclipse.jgit.transport.{JschConfigSessionFactory, SshTransport, Transport, UsernamePasswordCredentialsProvider}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Random, Success, Try}
+import notebook.io.FutureUtil._
+
+trait GitProvider {
+  def init()(implicit ec:ExecutionContext): Future[Unit]
+  def refreshLocal()(implicit ec:ExecutionContext): Future[Unit]
+  def add(relativePath: String, commitMessage: String)(implicit ec:ExecutionContext): Future[Unit]
+  def push()(implicit ec:ExecutionContext) : Future[Unit]
+  def remove(relativePath: String, commitMessage: String)(implicit ec:ExecutionContext): Future[Unit]
+  def checkout(relativePath: String, commit: String)(implicit ec:ExecutionContext): Future[Unit]
+  def versions(relativePath: String)(implicit ec:ExecutionContext): Future[List[Version]]
+
+  def gitContext: GitContext
+}
+
+trait GitContext {
+  def git: Git
+  def branch: String
+  def commitMessages: CommitMessages
+  def localPath: Path
+
+  // some shortcuts for the GIT Porcelain API
+  def rm = git.rm()
+  def commit = git.commit()
+  def add = git.add()
+  def checkout = git.checkout()
+  def log = git.log()
+}
+
+object GitContext {
+  object implicits {
+    implicit class CloneCommandOps(val cmd : CloneCommand) extends AnyRef {
+      def setURI(uri:URI) = cmd.setURI(uri.toString)
+    }
+  }
+}
+
+trait RemoteGitContext extends GitContext {
+  def auth: Auth
+  def remote: URI
+
+  // some shortcuts for the GIT Porcelain API
+  def pull = git.pull()
+  def push = git.push()
+}
+
+trait LocalGitProvider extends GitProvider { gitCtx : GitContext =>
+
+  override def refreshLocal()(implicit ec:ExecutionContext): Future[Unit] = Future.successful()
+
+  override def add(relativePath: String, commitMessage: String)(implicit ec:ExecutionContext): Future[Unit] = {
+    Future {
+      gitCtx.add.addFilepattern(relativePath).call()
+      gitCtx.commit.setMessage(commitMessage).call()
+    }
+  }
+
+  override def push()(implicit ec:ExecutionContext): Future[Unit] = Future.successful()
+
+  override def remove(relativePath: String, commitMessage: String)(implicit ec:ExecutionContext): Future[Unit] = {
+    Future {
+      gitCtx.rm.addFilepattern(relativePath).call()
+      gitCtx.commit.setMessage(commitMessage).call()
+    }
+  }
+
+  override def checkout(relativePath: String, commit: String)(implicit ec:ExecutionContext): Future[Unit] = {
+    Future{
+      gitCtx.checkout.addPath(relativePath).setForce(true).setStartPoint(commit).call()
+    }
+  }
+
+  override def versions(relativePath: String)(implicit ec:ExecutionContext): Future[List[Version]] = Future {
+    import scala.collection.JavaConverters._
+    val logs = gitCtx.log.addPath(relativePath).call()
+    logs.iterator().asScala.toList.map(commitRef => Version(commitRef.name(), commitRef.getFullMessage, commitRef.getCommitTime))
+  }
+
+}
+
+trait RemoteGitProvider extends LocalGitProvider { gitCtx: RemoteGitContext =>
+
+  override def refreshLocal()(implicit ec:ExecutionContext): Future[Unit] = Future {
+    gitCtx.auth(gitCtx.pull).call()
+  }
+
+  override def push()(implicit ec:ExecutionContext):Future[Unit] = Future {
+    // FIXME: ideally we shouldn't need to force the pushUrl
+    gitCtx.auth(gitCtx.push.setRemote(gitCtx.remote.toString)).call()
+  }
+
+}
+
+sealed trait Auth {
+  def apply[T1 <: TransportCommand[T1, _], _](cmd: T1 ): T1
+}
+
+class KeyFileAuth(keyFile: String, passphrase: Option[String]) extends Auth {
+  def apply[T1 <: TransportCommand[T1, _], _](cmd: T1): T1 = {
+    val keyFileTransportConfigCallback = new TransportConfigCallback {
+      override def configure(transport: Transport): Unit = {
+        val t = transport.asInstanceOf[SshTransport]
+        t.setSshSessionFactory(new JschConfigSessionFactory {
+
+          import org.eclipse.jgit.util.FS
+          import com.jcraft.jsch.JSch
+
+          override protected def createDefaultJSch(fs: FS): JSch = {
+            val default = super.createDefaultJSch(fs)
+            default.removeAllIdentity()
+            passphrase match {
+              case Some(pass) => default.addIdentity(keyFile, pass)
+              case None => default.addIdentity(keyFile)
+            }
+            default
+          }
+
+          override def configure(hc: Host, session: Session): Unit = {
+            session.setConfig("StrictHostKeyChecking", "no")
+          }
+        })
+      }
+    }
+    cmd.setTransportConfigCallback(keyFileTransportConfigCallback)
+  }
+}
+
+class PasswordAuth(password:String) extends Auth {
+  def apply[T1 <: TransportCommand[T1, _], _](cmd: T1): T1 = {
+    val passwordTransportConfigCallback = new TransportConfigCallback {
+      override def configure(transport: Transport): Unit = {
+        val t = transport.asInstanceOf[SshTransport]
+        t.setSshSessionFactory(new JschConfigSessionFactory {
+          override def configure(hc: Host, session: Session): Unit = {
+            session.setPassword(password)
+          }
+        })
+      }
+    }
+    cmd.setTransportConfigCallback(passwordTransportConfigCallback)
+  }
+}
+
+class UsernamePasswordAuth(username: String, password: String) extends Auth {
+  override def apply[T1 <: TransportCommand[T1, _], _](cmd: T1): T1 = {
+    val cred = new UsernamePasswordCredentialsProvider(username, password)
+    cmd.setCredentialsProvider(cred)
+    cmd
+  }
+}
+
+case class CommitMessages(initialCommit: String, delete: String, commit: String, move: String)
+
+object CommitMessagesConfiguration extends Configurable[CommitMessages] {
+  import ConfigUtils._
+
+  val DefaultInitialCommit: String = "Initial commit"
+  val DefaultDeleteMessage: String = "Removed file"
+  val DefaultCommitMessage: String = "Saved file"
+  val DefaultMoveMessage: String = "Moved file"
+
+  def apply(config: Config)(implicit ec:ExecutionContext): Future[CommitMessages] = {
+    val initialCommitMessage = config.getSafeString("messages.initial_commit").getOrElse(DefaultInitialCommit)
+    val commitMessageSave = config.getSafeString("messages.save").getOrElse(DefaultCommitMessage)
+    val commitMessageRemove = config.getSafeString("messages.remove").getOrElse(DefaultDeleteMessage)
+    val commitMessagesMove = config.getSafeString("messages.move").getOrElse(DefaultMoveMessage)
+    Future(CommitMessages(initialCommitMessage, commitMessageRemove, commitMessageSave, commitMessagesMove ))
+  }
+
+}
+
+case class LocalRepo(
+                      pathState: PathState,
+                      override val branch:String,
+                      override val commitMessages: CommitMessages
+                    ) extends GitContext with LocalGitProvider {
+  val repository: Repository = new FileRepositoryBuilder().setWorkTree(pathState.toFile).build()
+  override lazy val git = new Git(repository)
+  override val localPath: Path = pathState.path
+  override def gitContext: GitContext = this
+
+  def init()(implicit ec:ExecutionContext): Future[Unit] = Future {
+    pathState match {
+      case ep: EmptyPath => // Init git in there
+        Git.init().setBare(false).setDirectory(ep.toFile).call()
+        if (branch != GitNotebookProvider.DefaultBranch) {
+          checkout.setCreateBranch(true).setName(branch).call()
+        }
+
+      // This case might not work (creating a branch that might already exist)
+      case nep: NonEmptyGitPath => // Use existing local GIT repo
+        //Git.init().setBare(false).setDirectory(_localPathState.toFile).call() ??
+        if (branch != GitNotebookProvider.DefaultBranch) {
+          checkout.setCreateBranch(true).setName(branch).call()
+        }
+
+      case negp: NonEmptyNonGitPath => // existing non-git path, init git repo and add everything in there
+        Git.init().setBare(false).setDirectory(negp.toFile).call()
+        val repoLocation = negp.toFile.toString
+        add.addFilepattern(repoLocation).call()
+        commit.setMessage(s"${commitMessages.initialCommit} $repoLocation").call()
+    }
+  }
+
+  // path location of this repo
+  def path: Path = pathState.path
+
+}
+
+object LocalRepoConfiguration {
+  import ConfigUtils._
+
+  val LocalPathKey = "local_path"
+
+  def parse(config:Config, commitMessages: CommitMessages) : Try[LocalRepo] = {
+    val branch = config.getSafeString("branch").getOrElse(GitNotebookProvider.DefaultBranch)
+    config.tryGetString(LocalPathKey).flatMap(str => PathState(str)).map(ps => LocalRepo(ps, branch, commitMessages))
+  }
+}
+
+case class RemoteRepo(
+                       localRepo: LocalRepo,
+                       override val remote: URI,
+                       override val auth: Auth
+                     ) extends RemoteGitContext with RemoteGitProvider {
+  override val git = localRepo.git
+  override val branch = localRepo.branch
+  override val commitMessages = localRepo.commitMessages
+  override val localPath: Path = localRepo.pathState.path
+  override def gitContext: GitContext = this
+  import GitContext.implicits._
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  override def init()(implicit ec:ExecutionContext): Future[Unit] =  localRepo.pathState match {
+    // Empty local dir => clone remote
+    case ep: EmptyPath => cloneToLocal()
+
+    case negp: NonEmptyGitPath => // existing path is assumed to be a clone of the remote.
+      Future{checkout.setName(branch).call(); ()}
+
+    case negp: NonEmptyNonGitPath => // we don't support an existing non-git directory. Set aside and re-recreate
+      moveCurrentPath()
+      Future{PathState.create(localRepo.path)}.flatMap(_ => cloneToLocal())
+  }
+
+  private[io] def moveCurrentPath() : Unit = {
+    val currentPath = localRepo.path
+    val dirname = currentPath.getFileName
+    val targetDirName = s"$dirname.moved-${System.currentTimeMillis()}-${Random.nextInt(1000)}"
+    val targetMovePath = currentPath.resolveSibling(targetDirName)
+    Files.move(currentPath, targetMovePath)
+  }
+
+  private[io] def cloneToLocal(): Future[Unit] = Future {
+    val cmd = Git.cloneRepository().setCloneAllBranches(true)
+    cmd.setDirectory(localRepo.path.toFile)
+    cmd.setURI(remote)
+    println(s"Cloning remote git repo '$remote' into '${localRepo.path.toFile}'; and switching branch to '$branch'")
+    auth(cmd).call()
+    checkout.setName(branch).call()
+    ()
+  }
+}
+
+object RemoteRepoConfiguration {
+
+  import ConfigUtils._
+
+  def toURI(s : String) : Try[URI] = Try(new URI(s))
+  def checkFileExists(file : String) : Try[String] = if (new File(file).exists() ) {
+    Success(file)
+  } else {
+    Failure(new ConfigurationCorruptException(s"Key file $file does not exist."))
+  }
+
+  def validateRepoUrl(repo: URI): Try[URI] = {
+    val SupportedProtocols = Set ("http", "https", "ssh")
+    if (SupportedProtocols( repo.getScheme )) {
+      Success(repo)
+    } else {
+      Failure(new ConfigurationCorruptException(s"Git repository protocol is not supported: ${repo.getScheme}"))
+    }
+  }
+
+  def parse(config:Config): Try[Option[LocalRepo => RemoteRepo]] = {
+
+    def mkRepo(location: URI, auth: Auth): Try[Option[LocalRepo => RemoteRepo]] = Success(Some(localRepo => RemoteRepo(localRepo, location, auth)))
+
+    val remoteURI = config.getSafeString("remote").map(x=> toURI(x).flatMap(validateRepoUrl _))
+
+    val authKey = config.getSafeString("authentication.key_file").map(checkFileExists _ )
+    val passphrase = config.getSafeString("authentication.key_file_passphrase")
+    val username = config.getSafeString("authentication.username")
+    val password = config.getSafeString("authentication.password")
+
+
+    (remoteURI, authKey, username, password) match {
+      case (None, _, _, _) => Success(None)
+      case (Some(Failure(ex)), _, _,_) => Failure(ex)
+      case (Some(Success(location)), Some(Failure(filex)), _, _) => Failure(filex)
+      case (Some(Success(location)), Some(Success(keyfile)), _, _) => mkRepo(location, new KeyFileAuth(keyfile, passphrase))
+      case (Some(Success(location)), None, Some(user), Some(pwd)) => mkRepo(location, new UsernamePasswordAuth(user, pwd))
+      case (Some(Success(location)), None, None, Some(pwd)) => mkRepo(location, new PasswordAuth(pwd))
+      case _ =>  Failure(new ConfigurationCorruptException("Invalid Remote Git Repository Configuration"))
+    }
+  }
+}
+
+class GitProviderConfigurator extends Configurable[GitProvider] {
+
+  override def apply(config: Config)(implicit ec:ExecutionContext): Future[GitProvider] = {
+
+    val repoConfig = for {
+      commitMessages <- CommitMessagesConfiguration(config)
+      local <- tryToFuture(LocalRepoConfiguration.parse(config, commitMessages))
+      remote <- tryToFuture(RemoteRepoConfiguration.parse(config))
+    } yield (local, remote)
+
+
+    repoConfig.flatMap { case (localRepo, remoteRepoFunc) =>
+      val gitProvider: GitProvider = remoteRepoFunc.map { localToRemote =>
+        localToRemote(localRepo)
+      }.getOrElse {
+        localRepo
+      }
+      gitProvider.init().map(_ => gitProvider)
+    }
+  }
+
+}

--- a/modules/git-notebook-provider/src/main/scala/notebook/io/PathState.scala
+++ b/modules/git-notebook-provider/src/main/scala/notebook/io/PathState.scala
@@ -1,0 +1,48 @@
+package notebook.io
+
+import java.io.{File, IOException}
+import java.nio.file.{Path, Paths}
+import org.apache.commons.io.FileUtils
+
+import scala.util.{Failure, Success, Try}
+
+
+sealed trait PathState {
+  def path:Path
+  def toFile:File = path.toFile
+}
+
+case class EmptyPath(val path:Path) extends PathState
+case class NonEmptyNonGitPath(val path:Path) extends PathState
+case class NonEmptyGitPath(val path:Path) extends PathState
+
+object PathState {
+  def apply(path : String): Try[PathState] = {
+    val targetPath = Paths.get(path)
+    val pathAsFile = targetPath.toFile
+    if (!pathAsFile.exists()) {
+      create(targetPath).map(_ => EmptyPath(targetPath))
+    } else {
+      val content = pathAsFile.list()
+      if (content.isEmpty) {
+        Success(EmptyPath(targetPath))
+      } else {
+        if (content.contains(".git")) {
+          Success(NonEmptyGitPath(targetPath))
+        } else {
+          Success(NonEmptyNonGitPath(targetPath))
+        }
+      }
+    }
+  }
+
+  def create(path:Path) : Try[Unit] = {
+    try {
+      FileUtils.forceMkdir(path.toFile)
+      Success(())
+    } catch {
+      case ex:IOException => new Failure (new ConfigurationCorruptException(s"Failed to create a directory under [${path}]"))
+    }
+  }
+}
+

--- a/modules/git-notebook-provider/src/test/scala/notebook/io/GitNotebookProviderNoCloneTests.scala
+++ b/modules/git-notebook-provider/src/test/scala/notebook/io/GitNotebookProviderNoCloneTests.scala
@@ -1,0 +1,69 @@
+package notebook.io
+
+import java.nio.file.Files
+import java.util.{Date, Properties}
+
+import com.typesafe.config.ConfigFactory
+import notebook.NotebookNotFoundException
+import org.apache.commons.io.FileUtils
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import org.eclipse.jgit.api.Git
+
+
+class GitNotebookProviderNoCloneTests extends TestBase {
+
+  import TestData._
+  import scala.collection.JavaConverters._
+
+  val notebook = TestData.notebook()
+
+  override def beforeAll: Unit = {
+    val providerConfig = new GitNotebookProviderConfigurator
+    emptyTemp = Files.createTempDirectory("git-no-clone-tests")
+    val conf = Map("local_path" -> emptyTemp.toString)
+    setProvider(providerConfig(ConfigFactory.parseMap(conf.asJava)))
+
+    target = emptyTemp.resolve(s"$testName.snb")
+  }
+
+  override def afterAll: Unit = {
+     FileUtils.deleteDirectory( emptyTemp.toFile )
+  }
+
+  "Git notebook provider" should {
+    import collection.JavaConversions._
+    def lastLog():String = gitNotebookProvider.gitProvider.gitContext.git.log().call().iterator().toIterable.head.getFullMessage
+
+    "create a repository" in {
+      emptyTemp.toFile.listFiles().toList should not be ('empty)
+    }
+
+    "create a notebook file" in {
+      whenReady(provider.save(target, notebook)) { n =>
+        n should be(notebook)
+        lastLog shouldBe (s"${CommitMessagesConfiguration.DefaultCommitMessage} ${testName}.snb")
+      }
+    }
+
+    "load created file" in {
+      whenReady( provider.get(target) ) { n =>
+        n should be (notebook)
+      }
+    }
+
+    "delete the file" in {
+      whenReady( provider.delete(target) ) { n =>
+        n should be (notebook)
+        lastLog shouldBe(s"${CommitMessagesConfiguration.DefaultDeleteMessage} ${testName}.snb")
+      }
+    }
+
+    "fail to load deleted file" in {
+      whenReady( provider.get(target).failed ) { n =>
+        n shouldBe a [NotebookNotFoundException]
+      }
+    }
+
+  }
+}

--- a/modules/git-notebook-provider/src/test/scala/notebook/io/GitNotebookProviderWithCloneTests.scala
+++ b/modules/git-notebook-provider/src/test/scala/notebook/io/GitNotebookProviderWithCloneTests.scala
@@ -1,0 +1,188 @@
+package notebook.io
+
+import java.nio.file.{Files, Path, Paths}
+import java.util.Properties
+
+import com.typesafe.config.ConfigFactory
+import notebook.NotebookNotFoundException
+import org.apache.commons.io.FileUtils
+import org.scalatest.Ignore
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import org.scalatest.time.{Millis, Seconds, Span}
+
+import scala.concurrent.Await
+import notebook.io.RemoteGitTestConfig._
+
+object RemoteGitTestConfig {
+  protected def getEnv(name: String): String = {
+    require(sys.env.isDefinedAt(name), s"Missing ENV var '$name'")
+    sys.env(name)
+  }
+
+  def getRemoteGitConfig(authType: String): Option[Properties] = {
+    authType match {
+      case "https" =>
+        val props = new Properties()
+        props.setProperty("remote", getEnv("TEST_GIT_REPO_HTTPS"))
+        props.setProperty("authentication.username", getEnv("TEST_GIT_USER"))
+        props.setProperty("authentication.password", getEnv("TEST_GIT_PASS"))
+        Option(props)
+      case "ssh" =>
+        val props = new Properties()
+        props.setProperty("remote", getEnv("TEST_GIT_REPO_SSH"))
+        props.setProperty("authentication.key_file", getEnv("TEST_GIT_KEYFILE"))
+        // FIXME: also test without keyfile passphare (as it is optional)
+        props.setProperty("authentication.key_file_passphrase", getEnv("TEST_GIT_KEYFILE_PASS"))
+        Option(props)
+      case _ => None
+    }
+
+  }
+}
+
+@Ignore
+class GitNotebookProviderCloneHttpsTests extends TestBase {
+
+  import TestData._
+
+  val remoteGitConfig = getRemoteGitConfig("https")
+
+  implicit val defaultPatience = PatienceConfig(timeout = Span(10, Seconds), interval = Span(500, Millis))
+  val testId = System.currentTimeMillis()
+  var props: Properties = _
+  val providerConfigurator = new GitNotebookProviderConfigurator
+  val notebook = TestData.notebook()
+
+  override def beforeAll: Unit = {
+    emptyTemp = Files.createTempDirectory("git-https-notebook-provider")
+    nonEmptyTemp = Files.createTempDirectory("git-https-notebook-provider-non-empty")
+
+    props = remoteGitConfig.get
+    props.setProperty("local_path", emptyTemp.toString)
+    props.setProperty("messages.save", s"[test-id:https:$testId] saved:")
+    props.setProperty("messages.remove", s"[test-id:https:$testId] removed:")
+
+    setProvider(providerConfigurator(ConfigFactory.parseProperties(props)))
+
+    target = emptyTemp.resolve(s"$testName-https.snb")
+  }
+
+  override def afterAll: Unit = {
+    FileUtils.deleteDirectory( emptyTemp.toFile )
+  }
+
+  s"HTTPS clone provider [test-id:https:$testId]" should {
+
+    "have the repository cloned in the temp directory" in {
+      val files = emptyTemp.toFile.listFiles().toList
+      files should not be ('empty)
+      files.exists(file=> file.getName == ".git") should be (true)
+    }
+
+    "create a notebook file" in {
+      whenReady( provider.save(target, notebook) ) { n =>
+        n shouldBe(notebook)
+      }
+    }
+
+    "load created file" in {
+      whenReady( provider.get(target) ) { n =>
+        n shouldBe(notebook)
+      }
+    }
+
+    "not load a non existing file" in {
+      whenReady( provider.get(Paths.get("/some/bogus/path")).failed ) { n =>
+        n shouldBe a [NotebookNotFoundException]
+      }
+    }
+
+    "delete the file" in {
+      assume(target.toFile.exists())
+      whenReady( provider.delete(target) ) { n =>
+        n shouldBe(notebook)
+        target.toFile.exists() shouldBe (false)
+      }
+    }
+
+    "fail to load deleted file" in {
+      whenReady( provider.get(target).failed ) { n =>
+        n shouldBe a [NotebookNotFoundException]
+      }
+    }
+
+    "reuse an already cloned repository cloned in the temp directory" in {
+      val otherProviderConf = new GitNotebookProviderConfigurator
+      val otherProvider = Await.result(otherProviderConf(ConfigFactory.parseProperties(props)), DefaultWaitSeconds)
+      otherProvider.asInstanceOf[ConfigurableGitNotebookProvider]
+        .gitProvider.gitContext.branch shouldBe (GitNotebookProvider.DefaultBranch)
+    }
+  }
+}
+
+@Ignore
+// This test is currently failing
+class GitNotebookProviderCloneSshTests extends TestBase {
+
+  import TestData._
+
+  val remoteGitConfig = getRemoteGitConfig("ssh")
+
+  implicit val defaultPatience = PatienceConfig(timeout = Span(10, Seconds), interval = Span(500, Millis))
+  val testId = System.currentTimeMillis()
+  val providerConfigurator = new GitNotebookProviderConfigurator
+  val notebook = TestData.notebook()
+
+  override def beforeAll: Unit = {
+    emptyTemp = Files.createTempDirectory("git-ssh-notebook-provider")
+    target = emptyTemp.resolve(s"$testName-ssh.snb")
+  }
+
+  override def afterAll: Unit = {
+    FileUtils.deleteDirectory(emptyTemp.toFile)
+  }
+
+  s"SSH clone provider [test-id:ssh:$testId]" should {
+    "have the repository cloned in the temp directory" in {
+      assume(emptyTemp.toFile.list().isEmpty)
+
+      val props = remoteGitConfig.get
+      props.setProperty("local_path", emptyTemp.toString)
+      props.setProperty("branch", "master")
+      props.setProperty("messages.save", s"[test-id:ssh:$testId] saved:")
+      props.setProperty("messages.remove", s"[test-id:ssh:$testId] removed:")
+
+      setProvider(providerConfigurator(ConfigFactory.parseProperties(props)))
+
+      gitNotebookProvider.gitProvider.gitContext.branch shouldBe(GitNotebookProvider.DefaultBranch)
+      emptyTemp.toFile.list().toList should not be ('empty)
+    }
+
+    "create a notebook file" in {
+      whenReady( provider.save(target, notebook) ) { n =>
+        n shouldBe(notebook)
+      }
+    }
+
+    "load created file" in {
+      whenReady( provider.get(target) ) { n =>
+        n shouldBe(notebook)
+      }
+    }
+
+    "delete the file" in {
+      whenReady( provider.delete(target) ) { n =>
+        n shouldBe(notebook)
+      }
+    }
+
+    "fail to load deleted file" in {
+      whenReady( provider.get(target).failed ) { n =>
+        n shouldBe a [NotebookNotFoundException]
+      }
+    }
+
+  }
+
+}

--- a/modules/git-notebook-provider/src/test/scala/notebook/io/GitNotebookProviderWithCloneTests.scala
+++ b/modules/git-notebook-provider/src/test/scala/notebook/io/GitNotebookProviderWithCloneTests.scala
@@ -121,12 +121,11 @@ class GitNotebookProviderCloneHttpsTests extends TestBase {
 }
 
 @Ignore
-// This test is currently failing
 class GitNotebookProviderCloneSshTests extends TestBase {
 
   import TestData._
 
-  val remoteGitConfig = getRemoteGitConfig("ssh")
+  def remoteGitConfig = getRemoteGitConfig("ssh")
 
   implicit val defaultPatience = PatienceConfig(timeout = Span(10, Seconds), interval = Span(500, Millis))
   val testId = System.currentTimeMillis()
@@ -184,4 +183,16 @@ class GitNotebookProviderCloneSshTests extends TestBase {
 
   }
 
+}
+
+class GitNotebookProviderCloneSshWithGithubStyleURI extends GitNotebookProviderCloneSshTests {
+  // pass a Github style repo URL: git@github.com:organization/repo-name.git
+  override def remoteGitConfig() = {
+    super.remoteGitConfig.map { props =>
+      val githubStyleRemote = props.getProperty("remote").replace("ssh://git@github.com/", "git@github.com:")
+      println(s"Using Git remote: $githubStyleRemote")
+      props.setProperty("remote", githubStyleRemote)
+      props
+    }
+  }
 }

--- a/modules/git-notebook-provider/src/test/scala/notebook/io/GitNotebookProviderWithCloneTests.scala
+++ b/modules/git-notebook-provider/src/test/scala/notebook/io/GitNotebookProviderWithCloneTests.scala
@@ -41,7 +41,6 @@ object RemoteGitTestConfig {
   }
 }
 
-@Ignore
 class GitNotebookProviderCloneHttpsTests extends TestBase {
 
   import TestData._

--- a/modules/git-notebook-provider/src/test/scala/notebook/io/LocalGitProviderTests.scala
+++ b/modules/git-notebook-provider/src/test/scala/notebook/io/LocalGitProviderTests.scala
@@ -1,0 +1,104 @@
+package notebook.io
+
+import java.io.File
+import java.nio.file.{Files, Path, Paths}
+
+import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.lib.Repository
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.io.Source
+
+
+
+class LocalGitProviderTests extends WordSpec with Matchers with BeforeAndAfterAll {
+
+  var emptyTemp: Path = _
+  var localGitProvider: LocalGitProvider = _
+
+  override def beforeAll(): Unit = {
+    emptyTemp = Files.createTempDirectory("local-git-tests")
+    localGitProvider = new TestLocalGitProvider(emptyTemp)
+    Await.ready(localGitProvider.init(), 5 seconds)
+    println ("using dir: " + emptyTemp)
+  }
+
+  class TestGitContext(testDir: Path) extends GitContext {
+
+    val repository: Repository = new FileRepositoryBuilder().setWorkTree(testDir.toFile).build()
+
+    override def git: Git = new Git(repository)
+
+    override def commitMessages: CommitMessages = CommitMessages("Initial commit", "delete bum", "committed like a pig", "moved around")
+
+    override def branch: String = "master"
+
+    override def localPath: Path = testDir
+  }
+
+
+class TestLocalGitProvider(testDir:Path) extends TestGitContext(testDir) with LocalGitProvider { ctx: GitContext =>
+
+  override def init()(implicit ec: ExecutionContext): Future[Unit] = Future {
+    Git.init().setBare(false).setDirectory(testDir.toFile).call()
+  }
+  override def gitContext: GitContext = ctx
+
+}
+
+  "LocalGitProvider" should {
+    "commit a file with a commit message" in {
+      val filename = "afile.txt"
+      val commitMsg = "commit message"
+      fileWithContent(filename)("Some Data")
+
+      val fVersions = for {
+        _ <- localGitProvider.add(filename, commitMsg)
+        versions <- localGitProvider.versions(filename)
+      } yield versions
+      val versions = Await.result(fVersions, 10 seconds)
+
+      versions.size should be (1)
+      versions.head.message should be (commitMsg)
+    }
+
+    "checkout a given version" in {
+      val filename = "somefile.txt"
+
+      val adds: Future[Path] = for {
+        file <- Future(fileWithContent(filename)("Some Data"))
+        _ <- localGitProvider.add(filename, "first commit")
+        _ <- Future(fileWithContent(filename)("Some More Data"))
+        _ <- localGitProvider.add(filename, "second commit")
+        _ <- Future(fileWithContent(filename)("Error"))
+        _ <- localGitProvider.add(filename, "third commit")
+      } yield (file)
+
+      val file = Await.result(adds, 10 seconds)
+
+      val futVersions = localGitProvider.versions(filename)
+      val versions = Await.result(futVersions, 2 seconds)
+
+      val pickVersion = versions.drop(1).head
+      assume(pickVersion.message == "second commit")
+
+      Await.ready(localGitProvider.checkout(filename, pickVersion.id), 5 seconds)
+
+      val content = Source.fromFile(file.toFile).getLines().mkString("")
+      content should be ("Some More Data")
+    }
+  }
+
+
+  def fileWithContent(filename: String)(content:String = ""): Path = {
+    val file = emptyTemp.resolve(filename)
+    Files.write(file, content.getBytes("UTF-8"))
+    file
+  }
+
+
+}

--- a/modules/git-notebook-provider/src/test/scala/notebook/io/LocalRepoConfigTest.scala
+++ b/modules/git-notebook-provider/src/test/scala/notebook/io/LocalRepoConfigTest.scala
@@ -1,0 +1,58 @@
+package notebook.io
+
+import java.nio.file.{Files, Path}
+
+import com.typesafe.config.ConfigFactory
+import org.apache.commons.io.FileUtils
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{BeforeAndAfterAll, Matchers, TryValues, WordSpec}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.collection.JavaConverters._
+import FutureUtil._
+import org.scalatest.time.{Millis, Seconds, Span}
+
+class LocalRepoConfigTest extends WordSpec with Matchers with BeforeAndAfterAll with ScalaFutures with TryValues {
+
+  var testDir: Path = _
+
+  implicit val defaultPatience =  PatienceConfig(timeout = Span(5, Seconds), interval = Span(50, Millis))
+
+  override def beforeAll: Unit = {
+    testDir = Files.createTempDirectory("local-repo")
+  }
+
+  "LocalRepoConfig" should {
+    "use the directory in the configuration" in {
+      val config = ConfigFactory.parseMap(Map(LocalRepoConfiguration.LocalPathKey -> testDir.toString).asJava)
+      val eventualLocalRepo = for {
+        commitMessages <- CommitMessagesConfiguration(config)
+        localRepo <- tryToFuture(LocalRepoConfiguration.parse(config, commitMessages))
+      } yield localRepo
+
+      whenReady(eventualLocalRepo) { localRepo =>
+        localRepo.pathState shouldBe a[EmptyPath]
+      }
+    }
+
+    "fail with a missing configuration" in {
+      val config = ConfigFactory.empty()
+      val eventualLocalRepo = for {
+        commitMessages <- CommitMessagesConfiguration(config)
+        localRepoConfiguration <- tryToFuture(LocalRepoConfiguration.parse(config, commitMessages))
+      } yield localRepoConfiguration
+
+      whenReady(eventualLocalRepo.failed) { failedRepoConf =>
+        failedRepoConf match {
+          case ex: ConfigurationMissingException => ex.key should be(LocalRepoConfiguration.LocalPathKey)
+          case x => fail("Non compliant exception:" + x)
+        }
+      }
+    }
+  }
+
+  override def afterAll: Unit = {
+    FileUtils.deleteDirectory( testDir.toFile )
+  }
+
+}

--- a/modules/git-notebook-provider/src/test/scala/notebook/io/PathStateTests.scala
+++ b/modules/git-notebook-provider/src/test/scala/notebook/io/PathStateTests.scala
@@ -1,0 +1,72 @@
+package notebook.io
+
+import java.nio.file.{Files, Path}
+
+import org.apache.commons.io.FileUtils
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+
+
+class PathStateTests extends WordSpec with Matchers with BeforeAndAfterAll {
+
+  var testDir : Path = _
+  var emptyDir : Path = _
+  var nonExistingDir : Path = _
+  var nonEmptyDir : Path = _
+  var nonEmptyGitDir : Path = _
+
+  override def beforeAll: Unit = {
+
+    testDir = Files.createTempDirectory("path-state-test")
+
+    def mkdir(relPath:String) : Path = {
+      val path = testDir.resolve(relPath)
+      Files.createDirectory(path)
+      path
+    }
+
+    emptyDir = mkdir("empty")
+    nonExistingDir = testDir.resolve("non-exists")
+    nonEmptyDir = mkdir("non-empty")
+    nonEmptyGitDir = mkdir("non-empty-git")
+
+    val someFile = nonEmptyDir.resolve("file.txt")
+    Files.write(someFile, "SomeData".getBytes("UTF-8"))
+
+    val gitDir = nonEmptyGitDir.resolve(".git")
+    Files.createDirectory(gitDir)
+  }
+
+  override def afterAll: Unit = {
+    FileUtils.deleteDirectory( testDir.toFile )
+  }
+
+  "Path State" should {
+
+    "resolve an empty dir" in  {
+      val emptyPath = PathState(emptyDir.toFile.getAbsolutePath)
+      emptyPath should be ('success)
+      emptyPath.get shouldBe an [EmptyPath]
+    }
+
+    "resolve a non-existing dir and create it" in {
+      val nonExitingPath = PathState(nonExistingDir.toFile.getAbsolutePath)
+      nonExitingPath should be ('success)
+      nonExitingPath.get shouldBe an [EmptyPath]
+      nonExistingDir.toFile.exists() should be (true)
+    }
+
+    "resolve an existing dir with data" in {
+      val nonEmptyPath = PathState(nonEmptyDir.toFile.getAbsolutePath)
+      nonEmptyPath should be ('success)
+      nonEmptyPath.get shouldBe an [NonEmptyNonGitPath]
+    }
+
+    "resolve an existing git with data" in {
+      val gitPath = PathState(nonEmptyGitDir.toFile.getAbsolutePath)
+      gitPath  should be ('success)
+      gitPath.get shouldBe an [NonEmptyGitPath]
+    }
+
+  }
+
+}

--- a/modules/git-notebook-provider/src/test/scala/notebook/io/RemoteRepoConfigurationTests.scala
+++ b/modules/git-notebook-provider/src/test/scala/notebook/io/RemoteRepoConfigurationTests.scala
@@ -1,0 +1,94 @@
+package notebook.io
+
+import java.net.URI
+import java.nio.file.{Files, Path}
+
+import com.typesafe.config.{Config, ConfigFactory}
+import org.apache.commons.io.FileUtils
+import org.scalatest._
+
+import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+
+class RemoteRepoConfigurationTests extends WordSpec with Matchers with OptionValues with TryValues  with BeforeAndAfterAll {
+
+  val remoteRepoURI = "ssh://some.remote.com"
+
+  var testDir: Path = _
+
+  override def beforeAll: Unit = {
+    testDir = Files.createTempDirectory("remote-repo-test")
+  }
+
+  override def afterAll: Unit = {
+    FileUtils.deleteDirectory( testDir.toFile )
+  }
+
+  def localRepo ={
+    val config = ConfigFactory.parseMap(Map(LocalRepoConfiguration.LocalPathKey -> testDir.toString).asJava)
+    val eventualRepo = for {
+      commitMessages <- CommitMessagesConfiguration(config)
+      localRepo <- FutureUtil.tryToFuture(LocalRepoConfiguration.parse(config, commitMessages))
+    } yield {localRepo}
+      Await.result(eventualRepo, 5 seconds)
+  }
+
+
+  "RemoteRepoConfiguration" should {
+
+    "handle SSH repo URL" in {
+      RemoteRepoConfiguration.validateRepoUrl(new URI("ssh://user@example.com/repo.git")) shouldBe ('success)
+    }
+
+    "handle HTTP repo URL" in {
+      RemoteRepoConfiguration.validateRepoUrl(new URI("http://user@example.com/repo.git")) shouldBe ('success)
+    }
+
+    "handle HTTPS repo URL" in {
+      RemoteRepoConfiguration.validateRepoUrl(new URI("https://user@example.com/repo.git")) shouldBe ('success)
+    }
+
+    "fail to handle unsupported repo protocol" in {
+      val res = RemoteRepoConfiguration.validateRepoUrl(new URI("mqtt://user@example.com/repo.git"))
+      res shouldBe ('failure)
+      res.failed.get shouldBe an [ConfigurationCorruptException]
+    }
+
+    "correctly parse a missing remote configuration" in {
+      val config = ConfigFactory.empty()
+      RemoteRepoConfiguration.parse(config).success.value should be (None)
+    }
+
+    def configFrom(map:Map[String,String]):Config = ConfigFactory.parseMap(map.asJava)
+
+    "require further configuration if remote is present" in {
+      val config = configFrom(Map("remote" -> "ssh://some.remote.com"))
+      RemoteRepoConfiguration.parse(config).failure.exception shouldBe an [ConfigurationCorruptException]
+    }
+
+    "use a user/password combination " in {
+      val config = configFrom(Map("remote" -> remoteRepoURI,
+        "authentication.username" -> "user", "authentication.password" -> "pwd"
+      ))
+      val remoteRepoFunc = RemoteRepoConfiguration.parse(config).success.value.value
+      val remoteRepo = remoteRepoFunc(localRepo)
+      remoteRepo.remote.toString should be (remoteRepoURI)
+      remoteRepo.auth shouldBe an[UsernamePasswordAuth]
+    }
+
+    "use a password" in {
+      val config = configFrom(Map("remote" -> remoteRepoURI,
+        "authentication.password" -> "pwd"
+      ))
+      val remoteRepoFunc = RemoteRepoConfiguration.parse(config).success.value.value
+      val remoteRepo = remoteRepoFunc(localRepo)
+      remoteRepo.remote.toString should be (remoteRepoURI)
+      remoteRepo.auth shouldBe an [PasswordAuth]
+    }
+
+  }
+
+}

--- a/modules/git-notebook-provider/src/test/scala/notebook/io/TestBase.scala
+++ b/modules/git-notebook-provider/src/test/scala/notebook/io/TestBase.scala
@@ -1,0 +1,89 @@
+package notebook.io
+
+import java.nio.file.Path
+
+import notebook.Notebook
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Millis, Seconds, Span}
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import play.api.libs.json.{JsNumber, JsObject}
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
+
+class TestBase extends WordSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
+
+  val DefaultWait = 5 //seconds
+  val DefaultWaitSeconds = 5 seconds
+  implicit override val patienceConfig =
+    PatienceConfig(timeout = Span(5, Seconds), interval = Span(5, Millis))
+
+  var provider: NotebookProvider = _
+  var gitNotebookProvider: ConfigurableGitNotebookProvider = _
+
+  var emptyTemp: Path = _
+  var nonEmptyTemp: Path = _
+  var target: Path = _
+
+  def setProvider(fProv: Future[NotebookProvider]): Unit = {
+    provider = Await.result(fProv, DefaultWaitSeconds)
+    gitNotebookProvider = provider match {
+      case x: ConfigurableGitNotebookProvider => x
+      case _ => throw new RuntimeException("Invalid provided type detected at runtime")
+    }
+  }
+}
+
+object TestData  {
+
+  val notebookSer =
+    """{
+      |  "metadata" : {
+      |    "id" : "foo-bar-id",
+      |    "name" : "test-notebook-name",
+      |    "user_save_timestamp" : "1999-09-09T09:09:09.000Z",
+      |    "auto_save_timestamp" : "2001-01-01T00:00:00.000Z",
+      |    "language_info" : {
+      |      "name" : "scala",
+      |      "file_extension" : "scala",
+      |      "codemirror_mode" : "text/x-scala"
+      |    },
+      |    "trusted" : true,
+      |    "sparkNotebook" : {
+      |      "build" : "unit-tests"
+      |    },
+      |    "customLocalRepo" : "local-repo",
+      |    "customRepos" : [ "custom-repo" ],
+      |    "customDeps" : [ "\"org.custom\" % \"dependency\" % \"1.0.0\"" ],
+      |    "customImports" : [ "import org.cusom.dependency.SomeClass" ],
+      |    "customArgs" : [ ],
+      |    "customSparkConf" : {
+      |      "spark.driverPort" : 1234
+      |    }
+      |  },
+      |  "cells" : [ ]
+      |}
+    """.stripMargin
+
+  def notebook(): Notebook  = {
+    // weird sequence to normalize serialization artifacts (JSON indentation)
+    val deserNotebook = Notebook
+      .deserializeFuture(notebookSer)
+      .flatMap { nb =>
+        Notebook.serializeFuture(nb).flatMap(snb => Notebook.deserializeFuture(snb))
+      }
+    Await.result(deserNotebook, 5 second)
+  }
+
+  val testName = "test-notebook-name"
+  val sparkNotebook = Map("build" -> "unit-tests")
+  val customLocalRepo = Some("local-repo")
+  val customRepos = Some(List("custom-repo"))
+  val customDeps = Some(List(""""org.custom" % "dependency" % "1.0.0""""))
+  val customImports = Some(List("""import org.cusom.dependency.SomeClass"""))
+  val customArgs = Some(List.empty[String])
+  val customSparkConf = Some(JsObject( List(("spark.driverPort", JsNumber(1234))) ))
+
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,7 +39,7 @@ object Dependencies {
   val defaultSparkVersion = sys.props.getOrElse("spark.version", "2.0.1")
 
   val sparkVersionTuple = defaultSparkVersion match { case extractVs(v, m, p) =>  (v.toInt, m.toInt, p.toInt)}
-  val defaultScalaVersion = sys.props.getOrElse("scala.version", "2.10.6") match {
+  val defaultScalaVersion = sys.props.getOrElse("scala.version", "2.11.8") match {
     case x@scala_2_1X("0") => defaultSparkVersion match {
       case spark_X_Y("2", _, _)                => "2.10.6"
       case spark_X_Y(_, _, _)                  => x

--- a/project/Extra.scala
+++ b/project/Extra.scala
@@ -9,6 +9,7 @@ import scala.collection.mutable.ListBuffer
 object Extra {
   val sparkNotebookSettings: ListBuffer[Def.Setting[_]] = ListBuffer()
   val sparkNotebookCoreSettings: ListBuffer[Def.Setting[_]] = ListBuffer()
+  val gitNotebookProviderSettings: ListBuffer[Def.Setting[_]] = ListBuffer()
   val sbtDependencyManagerSettings: ListBuffer[Def.Setting[_]] = ListBuffer()
   val subprocessSettings: ListBuffer[Def.Setting[_]] = ListBuffer()
   val observableSettings: ListBuffer[Def.Setting[_]] = ListBuffer()

--- a/project/MainProperties.scala
+++ b/project/MainProperties.scala
@@ -1,6 +1,6 @@
 object MainProperties extends BuildConf {
   val fileName = ".main.build.conf"
 
-  val organization = getString("main.organization", "nooostab")
+  val organization = getString("main.organization", "io.kensu")
   val name         = getString("main.name", "spark-notebook")
 }

--- a/project/Shared.scala
+++ b/project/Shared.scala
@@ -17,7 +17,7 @@ object Shared {
     publishArtifact in Test := false,
     publishMavenStyle := true,
 
-    organization := "guru.data-fellas",
+    organization := MainProperties.organization,
     scalaVersion := defaultScalaVersion,
     sparkVersion := defaultSparkVersion,
     hadoopVersion := defaultHadoopVersion,

--- a/project/Shared.scala
+++ b/project/Shared.scala
@@ -15,6 +15,9 @@ object Shared {
 
   lazy val sharedSettings: Seq[Def.Setting[_]] = Seq(
     publishArtifact in Test := false,
+    publishMavenStyle := true,
+
+    organization := "guru.data-fellas",
     scalaVersion := defaultScalaVersion,
     sparkVersion := defaultSparkVersion,
     hadoopVersion := defaultHadoopVersion,

--- a/public/ipython/notebook/js/actions.js
+++ b/public/ipython/notebook/js/actions.js
@@ -388,17 +388,29 @@ define(function(require){
             },
         },
         'save-notebook':{
-            help: "Save and Checkpoint",
+            help: "Save",
             help_index : 'fb',
             icon: 'fa-save',
             handler : function (env, event) {
-                env.notebook.save_checkpoint();
+                env.notebook.save_notebook();
                 if(event){
                     event.preventDefault();
                 }
                 return false;
             }
         },
+        'checkpoint-notebook':{
+            help: "Save and Checkpoint",
+            help_index : 'ff',
+            icon: 'fa-flag',
+            handler : function (env, event) {
+                env.notebook.checkpoint_notebook();
+                if(event){
+                    event.preventDefault();
+                }
+                return false;
+            }
+        }
     };
 
     // private stuff that prepend `.ipython` to actions names

--- a/public/ipython/notebook/js/keyboardmanager.js
+++ b/public/ipython/notebook/js/keyboardmanager.js
@@ -69,6 +69,7 @@ define([
             'alt-enter'   : 'ipython.execute-and-insert-after',
             // cmd on mac, ctrl otherwise
             'cmdtrl-s'    : 'ipython.save-notebook',
+            'cmdtrl-shift-s'    : 'ipython.checkpoint-notebook',
         };
     };
 
@@ -120,6 +121,7 @@ define([
             't' : 'ipython.toggle-output-stream-visibility-selected-cell',
             'i' : 'ipython.toggle-input-visibility-selected-cell',
             's' : 'ipython.save-notebook',
+            'S' : 'ipython.checkpoint-notebook',
             'l' : 'ipython.toggle-line-number-selected-cell',
             'h' : 'ipython.show-keyboard-shortcut-help-dialog',
             'z' : 'ipython.undo-last-cell-deletion',

--- a/public/ipython/notebook/js/main.js
+++ b/public/ipython/notebook/js/main.js
@@ -22,11 +22,13 @@ require([
     'notebook/js/kernelselector',
     'codemirror/lib/codemirror',
     'notebook/js/about',
-    // only loaded, not used, please keep sure this is loaded last
+     // only loaded, not used, please keep sure this is loaded last
+    'observable',
     'custom/custom',
     'job_progress',
     'sidebar',
-    'chat'
+    'chat',
+    'checkpoints'
 ], function(
     IPython,
     $,
@@ -49,10 +51,13 @@ require([
     CodeMirror,
     about,
     // please keep sure that even if not used, this is loaded last
+    observable,
     custom,
     job_progress,
-    chat
-    ) {
+    sidebar,
+    chat,
+    checkpoints
+) {
     "use strict";
 
     // compat with old IPython, remove for IPython > 3.0
@@ -138,6 +143,7 @@ require([
             document.location.hash = hash;
         }
         notebook.set_autosave_interval(notebook.minimum_autosave_interval);
+        notebook.set_list_checkpoints_interval(notebook.minimum_list_checkpoints_interval);
         // only do this once
         events.off('notebook_loaded.Notebook', first_load);
     };

--- a/public/ipython/notebook/js/menubar.js
+++ b/public/ipython/notebook/js/menubar.js
@@ -176,7 +176,7 @@ define([
             that.notebook.save_checkpoint();
         });
 
-        this.element.find('#restore_checkpoint').click(function () {
+        this.element.find('#restore_checkpoint').click(function (e) {
         });
 
         this.element.find('#trust_notebook').click(function () {
@@ -390,7 +390,8 @@ define([
                 $("<li/>").append(
                     $("<a/>")
                     .attr("href", "#")
-                    .text(moment(d).format("LLLL"))
+                    .attr("title", moment(d).format("LLLL"))
+                    .text(checkpoint.message)
                     .click(function () {
                         that.notebook.restore_checkpoint_dialog(checkpoint);
                     })

--- a/public/ipython/services/contents.js
+++ b/public/ipython/services/contents.js
@@ -206,15 +206,6 @@ define(function (require) {
    * Checkpointing Functions
    */
 
-  Contents.prototype.create_checkpoint = function (path) {
-    var url = this.api_url(path, 'checkpoints');
-    var settings = {
-      type: "POST",
-      dataType: "json",
-    };
-    return utils.promising_ajax(url, settings);
-  };
-
   Contents.prototype.list_checkpoints = function (path) {
     var url = this.api_url(path, 'checkpoints');
     var settings = {

--- a/public/javascripts/notebook/checkpoints.js
+++ b/public/javascripts/notebook/checkpoints.js
@@ -1,0 +1,92 @@
+define([
+  'jquery',
+  'base/js/namespace',
+  'base/js/events',
+  'base/js/utils',
+  'knockout',
+  'underscore'
+], function($, IPython, events, utils, ko, _) {
+  var loaded = false;
+
+  var load_checkpoints = function() {
+    if (loaded) return;
+    require(['observable'], function(O) {
+      var CheckpointsModel = function() {
+        var self = this;
+
+        this.checkpoints = [];
+
+        this.renderedCheckpoints = ko.observableArray(null);
+
+        this.query = ko.observable(null).extend({ rateLimit: { //throttle
+                                                    timeout: 1000,
+                                                    method: "notifyWhenChangesStop"
+                                                  }
+                                                });
+        this.restore = function(checkpoint) {
+          IPython.notebook.restore_checkpoint_dialog(checkpoint);
+        };
+
+        this.renderCheckpoints = function(checkpoints) {
+          self.checkpoints = _.map(checkpoints, function(c) {
+            c.restore = function() { return self.restore(c); };
+            return c;
+          });  // keep original
+          self.renderFilteredCheckpoints(self.query());
+          //_.each(self.checkpoints, function(c) { self.renderedCheckpoints.push(c); });
+        };
+
+        this.renderFilteredCheckpoints = function(query) {
+          query = query || "";
+          // remove all the current beers, which removes them from the view
+          self.renderedCheckpoints.removeAll();
+
+          for(var x in self.checkpoints) {
+            var c = self.checkpoints[x];
+            if(c.message.toLowerCase().indexOf(query.toLowerCase()) >= 0) {
+              self.renderedCheckpoints.push(c);
+            }
+          }
+        };
+
+        events.on('checkpoints_listed.Notebook', function (checkpoints){
+          self.renderCheckpoints(IPython.notebook.checkpoints);
+        });
+
+        if (IPython.notebook.checkpoints) {
+          self.renderCheckpoints(IPython.notebook.checkpoints);
+        }
+
+        this.focus = function(){
+            IPython.notebook.keyboard_manager.edit_mode();
+            IPython.notebook.keyboard_manager.enable();
+        };
+        this.blur = function(){
+            IPython.notebook.keyboard_manager.command_mode();
+            events.trigger('command_mode.Cell', {cell: IPython.notebook.get_selected_cell()});
+        };
+
+        this.isTyping = ko.observable(false);
+        this.isTyping.subscribe(function(is) {
+          if (is) {
+            self.focus();
+          } else {
+            self.blur();
+          }
+        });
+
+        this.query.subscribe(this.renderFilteredCheckpoints);
+      };
+
+
+      model = new CheckpointsModel();
+      var checkpointsUI = $("#checkpoints-ui").get(0);
+      ko.cleanNode(checkpointsUI);
+      ko.applyBindings({ checkpoints: model }, checkpointsUI);
+    });
+  };
+
+  if (IPython.observable_ready) load_checkpoints();
+  else events.on('Observable.ready', load_checkpoints);
+
+});

--- a/public/javascripts/notebook/sidebar.js
+++ b/public/javascripts/notebook/sidebar.js
@@ -20,8 +20,8 @@ require(["jquery", "jquery.gridster", "jquerysticky"], function($, gridster, jqu
       $("#notebook-panels").trigger("sticky_kit:recalc");
     });
 
-    // start with sidebar hidden for now
-    $('a#toggle-sidebar').click();
+    // uncomment, to start with a hidden sidebar
+    // $('a#toggle-sidebar').click();
   });
 });
 

--- a/run-dev.sh
+++ b/run-dev.sh
@@ -7,9 +7,13 @@ export SN_NOTEBOOKS_GIT_HTTPS_REPO
 export SN_NOTEBOOKS_GIT_USER
 export SN_NOTEBOOKS_GIT_TOKEN
 
-RUN_MODE="${1:-"local"}"
+RUN_MODE="$1"
 
-echo "USAGE: ./run-dev.sh [local|git]"
+if [ "$RUN_MODE" = "" ]
+then
+  echo "USAGE: ./run-dev.sh [local|git]"
+  exit -1
+fi
 
 get_abs_filename() {
   # $1 : relative filename

--- a/run-dev.sh
+++ b/run-dev.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+export SPARK_LOCAL_IP=localhost
+
+# For git notebook storage to work, these env vars have to available (e.g. put in ~/.bashrc)
+export SN_NOTEBOOKS_GIT_HTTPS_REPO
+export SN_NOTEBOOKS_GIT_USER
+export SN_NOTEBOOKS_GIT_TOKEN
+
+RUN_MODE="${1:-"local"}"
+
+echo "USAGE: ./run-dev.sh [local|git]"
+
+get_abs_filename() {
+  # $1 : relative filename
+  echo "$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+}
+
+if [ "$RUN_MODE" = "git" ]
+then
+  DEFAULT_NB_DIR=$(get_abs_filename "$(pwd)/../sample-git-notebooks")
+  export NOTEBOOKS_DIR="${NOTEBOOKS_DIR:-"$DEFAULT_NB_DIR"}"
+  export CONFIG_FILE="conf/application-git-storage.conf"
+else
+  export NOTEBOOKS_DIR="${NOTEBOOKS_DIR:-"$(pwd)/notebooks"}"
+  export CONFIG_FILE="conf/application.conf"
+fi
+echo "Notebooks dir: $NOTEBOOKS_DIR . Config: $CONFIG_FILE"
+
+# "set offline := true"  \
+HADOOP_CONF_DIR=/etc/hadoop/conf:/etc/hive/conf sbt \
+  -Dconfig.file=${CONFIG_FILE} \
+  -Dwith.hive=true \
+  -Dwith.parquet=true \
+  -Dmanager.notebooks.override.sparkConf.spark.port.maxRetries=100 \
+  clean run

--- a/test-git-support.bash
+++ b/test-git-support.bash
@@ -1,12 +1,12 @@
-#!/usr/bin/bash
+#!/bin/bash
 
 export TEST_GIT_REPO_HTTPS="${SN_NOTEBOOKS_GIT_HTTPS_REPO}"
 export TEST_GIT_USER="${SN_NOTEBOOKS_GIT_USER}"
 export TEST_GIT_PASS="${SN_NOTEBOOKS_GIT_TOKEN}"
 
-export TEST_GIT_REPO_SSH="ssh://github.com/vidma/snb-tests.git"
-export TEST_GIT_KEYFILE="/Users/user/.ssh/test"
-export TEST_GIT_KEYFILE_PASS="test"
+export TEST_GIT_REPO_SSH="$SN_NOTEBOOKS_GIT_SSH_REPO"
+export TEST_GIT_KEYFILE="$SN_NOTEBOOKS_GIT_KEYFILE"
+export TEST_GIT_KEYFILE_PASS="$SN_NOTEBOOKS_GIT_KEYFILE_PASS"
 
 # TODO: currently one still needs to uncomment the @Ignore inside the tests
 sbt "project git-notebook-provider" "~test"

--- a/test-git-support.bash
+++ b/test-git-support.bash
@@ -1,0 +1,12 @@
+#!/usr/bin/bash
+
+export TEST_GIT_REPO_HTTPS="${SN_NOTEBOOKS_GIT_HTTPS_REPO}"
+export TEST_GIT_USER="${SN_NOTEBOOKS_GIT_USER}"
+export TEST_GIT_PASS="${SN_NOTEBOOKS_GIT_TOKEN}"
+
+export TEST_GIT_REPO_SSH="ssh://github.com/vidma/snb-tests.git"
+export TEST_GIT_KEYFILE="/Users/user/.ssh/test"
+export TEST_GIT_KEYFILE_PASS="test"
+
+# TODO: currently one still needs to uncomment the @Ignore inside the tests
+sbt "project git-notebook-provider" "~test"


### PR DESCRIPTION
This opensources support of notebook revision history. **Still Experimental**.
- `Filesystem` stays the default notebook storage, as it was
- `Git mode`  works as follows:
  * each edit (manual or autosave, if contents changed) becomes a git commit in a `local git dir`
  * if using a remote Git server (e.g. Github), it is cloned into the `local git dir` and each change commit is force pushed to the remote
- supported authentication methods:
  * http(s) - password or github token
  * SSH identity_file (password protection supported)
- it also allows to define other custom "storage providers"

see [git-notebook-provider/README](https://github.com/kensuio/spark-notebook/blob/d357b40e8b89682bf5d672c47cd5868bbd116140/modules/git-notebook-provider/README.md)

limitations to keep in mind: 
- each edit autosave currently creates a git commit. 
- config is slightly cumbersome. if git was configured incorrectly `spark-notebook` needs to be restarted, and it may be needed to clear the `local git dir` sometimes



![git_revision_history](https://cloud.githubusercontent.com/assets/213426/24368161/1a2d8de8-1328-11e7-94c6-ff7a51e2ad47.gif)


----

Changes:
- [x]  add abstract NotebookProviders interface
- [x] add FileSystemNotebookProvider
- [x] add Git notebook storage ( git-notebook-provider module)
  * see [git/README](https://github.com/kensuio/spark-notebook/blob/d357b40e8b89682bf5d672c47cd5868bbd116140/modules/git-notebook-provider/README.md) for details and configuration
  * see [conf/application-git-storage.conf](https://github.com/kensuio/spark-notebook/blob/d357b40e8b89682bf5d672c47cd5868bbd116140/conf/application-git-storage.conf) for example of how to configure it (environment variables are optional)
  * there is a [test-git-support.bash](https://github.com/kensuio/spark-notebook/blob/d357b40e8b89682bf5d672c47cd5868bbd116140/test-git-support.bash) which runs the tests on your git repo (config picked up from env variables)
- [x] add [run-dev.sh](https://github.com/kensuio/spark-notebook/blob/d357b40e8b89682bf5d672c47cd5868bbd116140/run-dev.sh) script which picks the right config
- [x] need to test if ssh auth with identity file (still) works
- [x] mention Git in the main README
- [x] hide revision-history when using a provider that do not support versions 231d702

cc @andypetrella @maasg 