### PR TITLE
Fix tests for Notebook versioning

### DIFF
--- a/modules/core/src/test/scala/notebook/io/NotebookProviderTests.scala
+++ b/modules/core/src/test/scala/notebook/io/NotebookProviderTests.scala
@@ -49,6 +49,7 @@ class NotebookProviderTests extends WordSpec with Matchers with BeforeAndAfterAl
 
   class BaseProvider extends NotebookProvider {
     type SaveSpec = Unit
+    override def isVersioningSupported: Boolean = true
     override def root: Path = rootPath
     override def get(path: Path, version: Option[Version])(implicit ev: ExecutionContext): Future[Notebook] = ???
     override def delete(path: Path)(implicit ev: ExecutionContext): Future[Notebook] = ???

--- a/modules/git-notebook-provider/src/test/scala/notebook/io/GitNotebookProviderWithCloneTests.scala
+++ b/modules/git-notebook-provider/src/test/scala/notebook/io/GitNotebookProviderWithCloneTests.scala
@@ -41,11 +41,12 @@ object RemoteGitTestConfig {
   }
 }
 
+@Ignore
 class GitNotebookProviderCloneHttpsTests extends TestBase {
 
   import TestData._
 
-  val remoteGitConfig = getRemoteGitConfig("https")
+  def remoteGitConfig = getRemoteGitConfig("https")
 
   implicit val defaultPatience = PatienceConfig(timeout = Span(10, Seconds), interval = Span(500, Millis))
   val testId = System.currentTimeMillis()
@@ -185,6 +186,7 @@ class GitNotebookProviderCloneSshTests extends TestBase {
 
 }
 
+@Ignore
 class GitNotebookProviderCloneSshWithGithubStyleURI extends GitNotebookProviderCloneSshTests {
   // pass a Github style repo URL: git@github.com:organization/repo-name.git
   override def remoteGitConfig() = {


### PR DESCRIPTION
fixes tests for #830 b519c8ba45dc7809068d05fa6333b67f529075b9

restore test ignores.

travis CI wasn't active, so we didn't catch silly test failures (I think because of repository rename).