### PR TITLE
Fix default impl. of NotebookProvider.list to properly relatavize root path

### DIFF
--- a/modules/core/src/main/scala/notebook/io/NotebookProvider.scala
+++ b/modules/core/src/main/scala/notebook/io/NotebookProvider.scala
@@ -65,7 +65,8 @@ trait NotebookProvider {
   }
 
   def list(path: Path)(implicit ec: ExecutionContext): Future[List[Resource]] = {
-    def relativePath(f: java.io.File): String = root.relativize(Paths.get(f.getAbsolutePath)).toString
+    val absRoot = root.toAbsolutePath
+    def relativePath(f: java.io.File): String = absRoot.relativize(Paths.get(f.getAbsolutePath)).toString
     Future {
       Option(root.resolve(path).toFile.listFiles(listFilter))
         .filter(_.length > 0) //toList fails if listFiles is empty


### PR DESCRIPTION
When running Spark Notebook with default configuration, an error occurs when listing the `/` root path of the notebooks directory.  This is because `Path.relatavize` requires an absolute path for `this` instance.

https://docs.oracle.com/javase/8/docs/api/java/nio/file/Path.html#relativize-java.nio.file.Path-

For example, when root is `./notebooks` and the path to relatavize is `/Users/seglo/source/spark-notebook/notebooks/adam` then an exception will be raised.

```
[INFO] listNotebooks at path /

[ERROR] 

! @73i4p6nde - Internal server error, for (GET) [/api/contents/?type=directory&_=1491504409383] ->

@73i4p6nde: Execution exception in null:null
        at play.api.Application$class.handleError(Application.scala:296)
        at play.api.DefaultApplication.handleError(Application.scala:402)
        at play.core.server.netty.PlayDefaultUpstreamHandler$$anonfun$14$$anonfun$apply$1.applyOrElse(PlayDefaultUpstreamHandler.scala:205)
        at play.core.server.netty.PlayDefaultUpstreamHandler$$anonfun$14$$anonfun$apply$1.applyOrElse(PlayDefaultUpstreamHandler.scala:202)
        at scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:36)
        at scala.util.Failure$$anonfun$recover$1.apply(Try.scala:216)
        at scala.util.Try$.apply(Try.scala:192)
        at scala.util.Failure.recover(Try.scala:216)
        at scala.concurrent.Future$$anonfun$recover$1.apply(Future.scala:326)
        at scala.concurrent.Future$$anonfun$recover$1.apply(Future.scala:326)
        at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:32)
        at play.api.libs.iteratee.Execution$trampoline$.execute(Execution.scala:46)
        at scala.concurrent.impl.CallbackRunnable.executeWithValue(Promise.scala:40)
        at scala.concurrent.impl.Promise$DefaultPromise.tryComplete(Promise.scala:248)
        at scala.concurrent.Promise$class.complete(Promise.scala:55)
        at scala.concurrent.impl.Promise$DefaultPromise.complete(Promise.scala:153)
        at scala.concurrent.impl.Future$PromiseCompletingRunnable.run(Future.scala:23)
        at akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:40)
        at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(AbstractDispatcher.scala:397)
        at scala.concurrent.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
        at scala.concurrent.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
        at scala.concurrent.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
        at scala.concurrent.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
Caused by: java.lang.IllegalArgumentException: 'other' is different type of Path
        at sun.nio.fs.UnixPath.relativize(UnixPath.java:416)
        at sun.nio.fs.UnixPath.relativize(UnixPath.java:43)
        at notebook.io.NotebookProvider$class.relativePath$1(NotebookProvider.scala:70)
        at notebook.io.NotebookProvider$$anonfun$list$1$$anonfun$apply$7.apply(NotebookProvider.scala:77)
        at notebook.io.NotebookProvider$$anonfun$list$1$$anonfun$apply$7.apply(NotebookProvider.scala:77)
        at scala.collection.immutable.List.map(List.scala:273)
        at notebook.io.NotebookProvider$$anonfun$list$1.apply(NotebookProvider.scala:77)
        at notebook.io.NotebookProvider$$anonfun$list$1.apply(NotebookProvider.scala:78)
        at scala.concurrent.impl.Future$PromiseCompletingRunnable.liftedTree1$1(Future.scala:24)
        at scala.concurrent.impl.Future$PromiseCompletingRunnable.run(Future.scala:24)
        at scala.concurrent.impl.ExecutionContextImpl$AdaptedForkJoinTask.exec(ExecutionContextImpl.scala:121)
        ... 4 more
```