### PR TITLE
Use a clean absolute notebooks.dir path

### DIFF
--- a/modules/core/src/main/scala/notebook/io/FileSystemNotebookProviderConfigurator.scala
+++ b/modules/core/src/main/scala/notebook/io/FileSystemNotebookProviderConfigurator.scala
@@ -15,7 +15,7 @@ class FileSystemNotebookProviderConfigurator extends Configurable[NotebookProvid
 
   override def apply(config: Config)(implicit ec:ExecutionContext): Future[NotebookProvider] = {
     val rootPath = Future {
-      Paths.get(config.getString(NotebooksDir))
+      getAbsoluteCanonicalPath(config.getString(NotebooksDir))
     }.recoverWith{ case t: Throwable =>
       Future.failed(new ConfigurationMissingException(NotebooksDir))
     }
@@ -67,4 +67,13 @@ class FileSystemNotebookProviderConfigurator extends Configurable[NotebookProvid
 }
 object FileSystemNotebookProviderConfigurator {
   val NotebooksDir = "notebooks.dir"
+
+  /**
+    * Get absolute path and remove any redundant ./ or ../../
+    */
+  def getAbsoluteCanonicalPath(path: String): Path = {
+    Paths.get(path)
+      .toAbsolutePath
+      .toFile.getCanonicalFile.toPath
+  }
 }


### PR DESCRIPTION
force path cleanup before initializing the filesystem provider.
(as NotebookProvider uses `rootPath.relativize` which do not work with non-canonical paths)


fixes #846 #847 (and this is a proper fix for #837 )