### PR TITLE
Remove duplicated notebooksDir logic

### DIFF
--- a/app/notebook/server/NotebookConfig.scala
+++ b/app/notebook/server/NotebookConfig.scala
@@ -31,11 +31,6 @@ case class NotebookConfig(config: Configuration) {
 
   val overrideConf = CustomConf.fromConfig(config.getConfig("notebooks.override"))
 
-  val notebooksDir = config.getString("notebooks.dir").map(new File(_)).filter(_.exists)
-    .orElse(Option(new File("./notebooks"))).filter(_.exists) // ./bin/spark-notebook
-    .getOrElse(new File("../notebooks")) // ./spark-notebook
-  Logger.info(s"Notebooks dir is $notebooksDir [at ${notebooksDir.getAbsolutePath}] ")
-
   val projectName = config.getString("name").getOrElse(notebooksDir.getPath)
 
   val defaultIoProviderTimeout = 60.seconds.toMillis
@@ -49,6 +44,9 @@ case class NotebookConfig(config: Configuration) {
       val configuration = config.tryGetConfig(notebookIoProviderClass).get
       NotebookProviderFactory.createNotebookIoProvider(notebookIoProviderClass, configuration.underlying, ioProviderTimeout)
   }
+
+  val notebooksDir = notebookIoProvider.root.toFile
+  Logger.info(s"Notebooks dir is $notebooksDir")
 
   val serverResources = config.getStringList("resources").map(_.asScala).getOrElse(Nil).map(new File(_))
 


### PR DESCRIPTION
use the same logic for retrieving `notebooksDir`as in [NotebookManager](https://github.com/spark-notebook/spark-notebook/blob/4d54f28bcbb43b363d4279f3c66be59a55adb5b1/app/notebook/server/NotebookManager.scala#L29) 

further cleanup after #849 