### PR TITLE
Fix save-notebook menu items

### DIFF
--- a/app/views/notebook.scala.html
+++ b/app/views/notebook.scala.html
@@ -72,7 +72,7 @@
                         <li id="rename_notebook"><a href="#">Rename/move...</a></li>
 
                         <li class="divider"></li>
-                        <li id="checkpoint_notebook"><a href="#">Save</a></li>
+                        <li id="save_notebook"><a href="#">Save</a></li>
                         <li id="save_checkpoint"><a href="#">Save (with commit message)</a></li>
                         <li id="restore_checkpoint" class="dropdown-submenu"><a href="#">Revert to Checkpoint</a>
                           <ul class="dropdown-menu">

--- a/app/views/notebook.scala.html
+++ b/app/views/notebook.scala.html
@@ -73,16 +73,18 @@
 
                         <li class="divider"></li>
                         <li id="save_notebook"><a href="#">Save</a></li>
-                        <li id="save_checkpoint"><a href="#">Save (with commit message)</a></li>
-                        <li id="restore_checkpoint" class="dropdown-submenu"><a href="#">Revert to Checkpoint</a>
-                          <ul class="dropdown-menu">
-                            <li><a href="#"></a></li>
-                            <li><a href="#"></a></li>
-                            <li><a href="#"></a></li>
-                            <li><a href="#"></a></li>
-                            <li><a href="#"></a></li>
-                          </ul>
-                        </li>
+                        @if(_root_.utils.AppUtils.isVersioningSupported){
+                          <li id="save_checkpoint"><a href="#">Save (with commit message)</a></li>
+                          <li id="restore_checkpoint" class="dropdown-submenu"><a href="#">Revert to Checkpoint</a>
+                            <ul class="dropdown-menu">
+                              <li><a href="#"></a></li>
+                              <li><a href="#"></a></li>
+                              <li><a href="#"></a></li>
+                              <li><a href="#"></a></li>
+                              <li><a href="#"></a></li>
+                            </ul>
+                          </li>
+                        }
                         <li class="divider"></li>
 
                         <!-- <li id="print_preview"><a href="#">Print Preview</a></li> -->

--- a/public/ipython/notebook/js/menubar.js
+++ b/public/ipython/notebook/js/menubar.js
@@ -176,6 +176,11 @@ define([
             that.notebook.save_checkpoint();
         });
 
+        this.element.find('#save_notebook').click(function (e) {
+            that.notebook.save_notebook();
+            e.preventDefault();
+        });
+
         this.element.find('#restore_checkpoint').click(function (e) {
         });
 

--- a/public/ipython/notebook/js/savewidget.js
+++ b/public/ipython/notebook/js/savewidget.js
@@ -225,7 +225,7 @@ define([
         if (dirty) {
             this.set_save_status("(unsaved changes)");
         } else {
-            this.set_save_status("(autosaved)");
+            this.set_save_status("(saved)");
         }
     };
 


### PR DESCRIPTION
- Bind file->save menu	fixes #845 
- Avoid confusion by incorrect `(autosaved)` message showed even after manual save -> change to `(saved)`
- Show version-control menu items only when supported

