### PR TITLE
Notebook listing: inline action buttons

### DIFF
--- a/public/ipython/custom/custom.css
+++ b/public/ipython/custom/custom.css
@@ -221,9 +221,11 @@ body[data-read-only="true"] .cell .progress, body[data-read-only="true"] #mainto
 .item_buttons_inline { display: inline; margin-left: 20px; }
 .item_buttons_inline .btn { border: none; margin-left: 10px; border-radius: 7px; font-size: 0.75em; /* background-color: transparent; border: 1px solid #f0f0f0; */ }
 
+
 .notebook_app {
-  background-color: #FAFAFA;
+  background-color: #fcfcfc;
 }
 
+.list_container > div.list_item.row { border: none!important; }
 .list_item.row:nth-child(even) {background: #FAFAFA}
 .list_item.row:nth-child(odd) {background: #FFFFFF}

--- a/public/ipython/custom/custom.css
+++ b/public/ipython/custom/custom.css
@@ -215,3 +215,8 @@ body[data-read-only="true"]  div.cell .cell-context-buttons {
 body[data-read-only="true"] .cell .progress, body[data-read-only="true"] #maintoolbar, body[data-read-only="true"] #menubar-container {
   display: none !important; visibility: hidden!important;
 }
+
+
+/* notebook list */
+.item_buttons_inline { display: inline; margin-left: 20px; }
+.item_buttons_inline .btn { border: none; margin-left: 10px; border-radius: 7px; font-size: 0.75em; /* background-color: transparent; border: 1px solid #f0f0f0; */ }

--- a/public/ipython/custom/custom.css
+++ b/public/ipython/custom/custom.css
@@ -220,3 +220,10 @@ body[data-read-only="true"] .cell .progress, body[data-read-only="true"] #mainto
 /* notebook list */
 .item_buttons_inline { display: inline; margin-left: 20px; }
 .item_buttons_inline .btn { border: none; margin-left: 10px; border-radius: 7px; font-size: 0.75em; /* background-color: transparent; border: 1px solid #f0f0f0; */ }
+
+.notebook_app {
+  background-color: #FAFAFA;
+}
+
+.list_item.row:nth-child(even) {background: #FAFAFA}
+.list_item.row:nth-child(odd) {background: #FFFFFF}

--- a/public/ipython/tree/js/notebooklist.js
+++ b/public/ipython/tree/js/notebooklist.js
@@ -11,6 +11,9 @@ define([
 ], function(IPython, $, utils, dialog, events, keyboard) {
     "use strict";
 
+    var item_buttons_class = "item_buttons_inline";
+    var item_buttons_selector = '.' + item_buttons_class;
+
     var NotebookList = function (selector, options) {
         /**
          * Constructor
@@ -250,7 +253,7 @@ define([
                 $("<span/>").addClass("item_name")
             )
         ).append(
-            $('<div/>').addClass("item_buttons  pull-right")
+            $('<div/>').addClass(item_buttons_class)
         ));
 
         if (index === -1) {
@@ -369,7 +372,7 @@ define([
                 $.ajax(url, settings);
                 return false;
             });
-        item.find(".item_buttons").append(shutdown_button);
+        item.find(item_buttons_selector).append(shutdown_button);
     };
 
     NotebookList.prototype.add_view_button = function (model, item, path) {
@@ -381,7 +384,7 @@ define([
         );
         url = this.maybe_read_only_url(url, true)
         var view_button = $("<a target='_blank' href="+url+"/>").html("<span class='text text-warning'>View (read-only)</span>").addClass("btn btn-default btn-xs");
-        item.find(".item_buttons").prepend(view_button);
+        item.find(item_buttons_selector).prepend(view_button);
     };
 
     NotebookList.prototype.add_duplicate_button = function (item) {
@@ -411,7 +414,7 @@ define([
                 });
                 return false;
             });
-        item.find(".item_buttons").append(duplicate_button);
+        item.find(item_buttons_selector).append(duplicate_button);
     };
 
     NotebookList.prototype.add_delete_button = function (item) {
@@ -445,7 +448,7 @@ define([
                 });
                 return false;
             });
-        item.find(".item_buttons").append(delete_button);
+        item.find(item_buttons_selector).append(delete_button);
     };
 
     NotebookList.prototype.notebook_deleted = function(path) {
@@ -575,7 +578,7 @@ define([
                 item.remove();
                 return false;
             });
-        item.find(".item_buttons").empty()
+        item.find(item_buttons_selector).empty()
             .append(upload_button)
             .append(cancel_button);
     };

--- a/public/stylesheets/user_custom.css
+++ b/public/stylesheets/user_custom.css
@@ -1,7 +1,1 @@
-.notebook_app {
-  background-color: #FAFAFA;
-}
-
-
-.list_item.row:nth-child(even) {background: #FAFAFA}
-.list_item.row:nth-child(odd) {background: #FFFFFF}
+/* this file is supposed to be overriden for user installation customizations, so left blank */


### PR DESCRIPTION
- [x] `user_custom.css` is supposed to be empty (it's for user style overrides)
- [x] make styles less intrusive (using softer colors)


<img width="843" alt="screen shot 2017-05-05 at 11 26 05" src="https://cloud.githubusercontent.com/assets/213426/25738415/b1cae2ba-3185-11e7-821d-d5aba2af2391.png">

<img width="584" alt="screen shot 2017-05-05 at 11 30 02" src="https://cloud.githubusercontent.com/assets/213426/25738496/34d9e976-3186-11e7-8790-26f50e4fe448.png">



P.S. I still don't like this much, but this should be a slightly better version of #841 