### PR TITLE
Open-source sbt-project-generator

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -18,7 +18,7 @@ import play.api.libs.iteratee.Concurrent.Channel
 import play.api.libs.iteratee._
 import play.api.libs.json._
 import play.api.mvc._
-import utils.AppUtils
+import utils.{SbtProjectGenUtils, AppUtils}
 import utils.Const.UTF_8
 
 import scala.concurrent.duration._
@@ -64,6 +64,13 @@ object Application extends Controller {
   val base_project_url = current.configuration.getString("application.context").getOrElse("/")
   val autoStartKernel = current.configuration.getBoolean("manager.kernel.autostartOnNotebookOpen").getOrElse(true) && !viewer;
   val kernelKillTimeout = current.configuration.getMilliseconds("manager.kernel.killTimeout")
+
+  lazy val sbt_project_gen_enabled = SbtProjectGenUtils.isConfigured
+  val docker_repo = current.configuration.getString("sbt-project-generation.publishing.dockerRepo").getOrElse("")
+  val maintainer = current.configuration.getString("sbt-project-generation.code-gen.maintainer").getOrElse("")
+  val deploy_package_base = current.configuration.getString("sbt-project-generation.code-gen.generatedPackageBase").getOrElse("generated")
+  val mesos_version = current.configuration.getString("sbt-project-generation.code-gen.mesosVersion").getOrElse("")
+
   val base_kernel_url = "/"
   val base_observable_url = "observable"
   val read_only = viewer
@@ -597,6 +604,11 @@ object Application extends Controller {
         "read-only" → read_only.toString,
         "base-url" → base_project_url,
         "notebook-path" → path,
+        "sbt_project_gen_enabled" -> sbt_project_gen_enabled.toString,
+        "docker-repo" → docker_repo,
+        "maintainer" → maintainer,
+        "deploy-package-base" → deploy_package_base,
+        "mesos-version" → mesos_version,
         "viewer_mode" → config.viewer.toString,
         "terminals-available" → terminals_available
       ),

--- a/app/controllers/GeneratedSbtProjects.scala
+++ b/app/controllers/GeneratedSbtProjects.scala
@@ -1,0 +1,205 @@
+package controllers
+
+import java.io.File
+import java.net.URLDecoder
+import java.nio.file.Paths
+
+import akka.actor._
+import com.datafellas.g3nerator.model._
+import notebook.io.ConfigurationMissingException
+import notebook.server.NotebookConfig
+import play.api.Play.current
+import play.api._
+import play.api.libs.json._
+import play.api.mvc._
+import utils.ConfigurationUtils._
+import utils.Const.UTF_8
+import utils.{SbtProjectGenUtils, AppUtils}
+
+import scala.language.postfixOps
+import scala.util.{Failure, Try}
+
+object GeneratedSbtProjects extends Controller {
+  private implicit def kernelSystem: ActorSystem = AppUtils.kernelSystem
+
+  val baseConfig = current.configuration
+  //val notebookConfig = NotebookConfig(baseConfig.getMandatoryConfig("manager"))
+
+  private def projectManager = SbtProjectGenUtils.projectManager.get
+  private def projectStore = SbtProjectGenUtils.projectStore.get
+
+  def logException[T](key:String):PartialFunction[Throwable, Try[T]] = {
+    case ex: Exception =>
+      Logger.error(s"Could not load config [$key]. Reason: [${ex.getMessage}]")
+      Failure(ex)
+  }
+
+  def sourcesFileName = "sources.zip"
+
+  def gitWebRootHttps: Option[String] = {
+    SbtProjectGenUtils.config.config.getString("git_www")
+  }
+
+  def readBuildStatus(outputDir: File) = {
+    val file = new File(outputDir, "compile.statuscode")
+    file match {
+      case f if f.exists() =>
+        val status = fileContent(f, from = 0).mkString
+        status match {
+          case "0" => "success"
+          case _ => "danger"
+        }
+      case _ => "warning" // not exists
+    }
+  }
+
+  def projects() = Action {
+    val arr = projectStore.list.map { generatedProject =>
+      val outputDir = (new File(projectManager.projectDir, generatedProject.outputDirectory.get)).toPath.toRealPath().toFile
+      val projectName = generatedProject.name.get
+
+      val downloadUrl: String = controllers.routes.GeneratedSbtProjects.downloadFile(projectName, sourcesFileName).url
+      val logO: Option[Array[String]] = for {
+        jobOut <- at(outputDir, "out")
+      } yield fileContent(jobOut, from = 0)
+
+      Json.obj(
+        "project" → generatedProject.outputDirectory,
+        "version" → generatedProject.version,
+        "job" → outputDir.exists,
+        "zip_archive_url" →  getProjectFile(projectName, sourcesFileName).toOption.map(_ => downloadUrl),
+        "git_repo_https_dir" →  gitWebRootHttps.map(_ + "/" + projectName),
+        "build_status" -> readBuildStatus(outputDir),
+        "services" → Seq[String]()
+      )
+    }
+    Ok(Json.toJson(arr))
+  }
+
+  private def fileContent(f:File, from:Int) = scala.io.Source.fromFile(f).getLines.drop(from).toArray
+
+  private def at(p:String, c:String):Option[File] = at(new File(p), c)
+
+  private def at(p:File, c:String):Option[File] = {
+    val f = new File(p, c)
+    if (f.exists) Some(f) else None
+  }
+
+  def fetchProject(projectName: String): Option[ProjectConfig] = {
+    projectStore.list.find(_.outputDirectory == Some(projectName))
+  }
+
+  def getProjectFile(projectName: String, fileName: String): Try[File] = {
+    for {
+      project <- Try(fetchProject(projectName).get)
+      outputDir <- Try(new File(new File(projectManager.projectDir, project.outputDirectory.get), "/" + fileName)) if outputDir.exists()
+    } yield outputDir
+  }
+
+  def downloadFile(projectName: String, fileName: String) = Action {
+    getProjectFile(projectName, fileName).map { projectZipFile =>
+      Ok.sendFile(content = projectZipFile, fileName = _ => s"$projectName-$fileName")
+    }.getOrElse(BadRequest(s"$fileName for project $projectName not found!"))
+  }
+
+  def projectInfo(projectName:String, from:Int) = Action {
+    projectStore.list.find(_.outputDirectory == Some(projectName)).map { f =>
+      val dir = new File(projectManager.projectDir, f.outputDirectory.get)
+      val logO: Option[Array[String]] = for {
+        jobOut <- at(dir, "out")
+      } yield fileContent(jobOut, from)
+
+      val log:Array[String] = logO.getOrElse(Array.empty[String])
+
+      Ok(Json.obj(
+        "name" → projectName,
+        "generated" → "job",
+        "log" → log
+      ))
+    }.getOrElse(BadRequest(s"Project $projectName not found!"))
+  }
+
+
+  def artifactoryURI: Option[((String, String), Option[(String, String)])] = {
+    val pullPushOption:Option[(String, String)] = for {
+      pull <- current.configuration.getString("sbt-project-generation.publishing.artifactory.pull")
+      push <- current.configuration.getString("sbt-project-generation.publishing.artifactory.push")
+    } yield (pull, push)
+    val credOption = for {
+      user <- current.configuration.getString("sbt-project-generation.publishing.artifactory.user")
+      password <- current.configuration.getString("sbt-project-generation.publishing.artifactory.password")
+    } yield (user, password)
+    pullPushOption.map { pp =>
+      pp → credOption
+    }
+  }
+
+  def sbtDependencyConfig: DependencyConfig = {
+    val urlResolverCloudera = current.configuration.getString("sbt-project-generation.dependencies.cloudera").getOrElse("https://repository.cloudera.com/artifactory/cloudera-repos")
+    val urlResolverBintrayDataFellasMvn = current.configuration.getString("sbt-project-generation.dependencies.bintray-data-fellas-maven").getOrElse("http://dl.bintray.com/data-fellas/maven")
+    val urlResolverBintraySparkPackagesMvn = current.configuration.getString("sbt-project-generation.dependencies.bintray-spark-packages").getOrElse("http://dl.bintray.com/spark-packages/maven/")
+    val jdkHome = current.configuration.getString("sbt-project-generation.dependencies.jdk_home").getOrElse(throw new ConfigurationMissingException("sbt-project-generation.dependencies.jdk_home"))
+    val sbtHome = current.configuration.getString("sbt-project-generation.dependencies.sbt_home").getOrElse(throw new ConfigurationMissingException("sbt-project-generation.dependencies.sbt_home"))
+
+    val urlDockerBaseImage = current.configuration.getString("sbt-project-generation.dependencies.docker-base-image").getOrElse("data-fellas-docker-public.bintray.io/base-adst:0.0.1")
+    val urlResolverSbtPlugin = current.configuration.getString("sbt-project-generation.dependencies.sbt-plugin-releases").getOrElse("http://repo.scala-sbt.org/scalasbt/sbt-plugin-releases")
+
+    com.datafellas.g3nerator.model.DependencyConfig(
+      urlResolverCloudera,
+      urlResolverBintrayDataFellasMvn,
+      urlResolverBintraySparkPackagesMvn,
+      Paths.get(jdkHome),
+      Paths.get(sbtHome),
+      urlDockerBaseImage,
+      urlResolverSbtPlugin,
+      artifactoryURI
+    )
+  }
+
+
+  def generateNbProject(fp: String) = Action(parse.tolerantText) { request =>
+    val path = URLDecoder.decode(fp, UTF_8)
+    val text = request.body
+    val json = Json.parse(request.body)
+
+    Logger.info("Generating project for notebook:" + path)
+    val toDir = (json \ "to_dir").as[String]
+    val pkg = (json \ "pkg").as[String]
+    val version = (json \ "version").as[String]
+    val maintainer = (json \ "maintainer").as[String]
+    val dockerRepo = (json \ "docker_repo").as[String]
+    val mesosVersion = (json \ "mesos_version").as[String]
+
+    implicit val ec = kernelSystem.dispatcher
+
+    // FIXME: do we need to override some configs ?!
+    // val nbContent = notebookConfig.overrideConf.merge(path)//.map(notebook.Notebook.write)
+    val nbContent = utils.AppUtils.notebookManager.load(path)
+
+    nbContent match {
+      case Some(nbFile) =>
+        val isPublishLocal = current.configuration.getBoolean("sbt-project-generation.mode.local").getOrElse(false) // ignored
+
+        val prod = for {
+          sv <- current.configuration.getString("sbt-project-generation.code-gen.sparkVersion")
+          hv <- current.configuration.getString("sbt-project-generation.code-gen.hadoopVersion")
+        } yield com.datafellas.g3nerator.model.ProductionConfig(sv, hv)
+
+        val projectConfig = ProjectConfig(
+          pkg,
+          version,
+          maintainer,
+          dockerRepo,
+          "hdfs://namenode1.hdfs.mesos:50071/docker/docker.tar.gz", // TODO: not good!!!!
+          mesosVersion
+        )
+
+        val project = new Project(nbFile, projectManager.projectDir, projectConfig, sbtDependencyConfig, productionConfig = prod)
+        val result = projectManager.publish(project, isPublishLocal)
+        result.onFailure{ case ex:Exception => Logger.error(s"Project generation failed. Reason: ${ex.getMessage}", ex)}
+        Ok(Json.obj("to_dir" → toDir))
+      case None =>
+        BadRequest("Cannot read and merge notebook")
+    }
+  }
+}

--- a/app/notebook/server/SbtProjectGenConfig.scala
+++ b/app/notebook/server/SbtProjectGenConfig.scala
@@ -1,0 +1,34 @@
+package com.datafellas.notebook.adastyx.server
+
+import java.io.File
+
+import com.typesafe.config.Config
+import scala.concurrent.duration._
+import play.api.{Logger, _}
+
+case class SbtProjectGenConfig(config: Configuration) { me =>
+
+  import play.api.Play.current
+
+  val DefaultTimeout = 90.seconds.toMillis
+
+  val projectsDirConf = config.getString("projects.dir")
+
+  val providerTimeout: Duration = {
+    val timeout = config.getMilliseconds("io.provider_timeout").getOrElse(DefaultTimeout)
+    new FiniteDuration(timeout, MILLISECONDS)
+  }
+
+  // no eager creation of this location
+  val projectsDir = projectsDirConf.map(new File(_)).getOrElse {
+    throw new RuntimeException("Missing sbt-project-generation.projects.dir configuration key")
+  }
+
+  val underlying: Config = config.underlying
+  Logger.info(s"Provider timeout is $providerTimeout")
+  Logger.info(s"Projects dir is $projectsDir ")
+  Logger.info(s"Projects dir exists? ${projectsDir.exists()} ")
+  if (projectsDir.exists()) {
+    Logger.info(s"Projects content:" + projectsDir.listFiles().map(_.getName).mkString(", "))
+  }
+}

--- a/app/utils/SbtProjectGenUtils.scala
+++ b/app/utils/SbtProjectGenUtils.scala
@@ -1,0 +1,52 @@
+package utils
+
+import notebook.io.{ConfigurationMissingException, GitProvider, GitProviderConfigurator}
+import com.datafellas.g3nerator.{FileProjectStore, ProjectManager}
+import com.datafellas.notebook.adastyx.server.SbtProjectGenConfig
+import com.typesafe.config.ConfigFactory
+
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.Try
+
+object SbtProjectGenUtils {
+
+  import play.api.Play.current
+
+  def config = {
+    val conf = current.configuration.getConfig("sbt-project-generation")
+      .getOrElse(throw new RuntimeException("Could not find [sbt-project-generation] configuration"))
+    SbtProjectGenConfig(conf)
+  }
+
+  def projectsDirName: String = {
+    config.projectsDirConf.getOrElse(throw new ConfigurationMissingException("sbt-project-generation.projects.dir"))
+  }
+
+  protected def projectsDir = config.projectsDir
+
+  protected def providerTimeout = config.providerTimeout
+
+  protected def gitProvider: GitProvider = {
+    import collection.JavaConverters._
+    val gitProjectsDirConf = ConfigFactory.parseMap(Map("local_path" -> projectsDirName).asJava)
+    val gitConfig = config.underlying.withFallback(gitProjectsDirConf)
+    Await.result(new GitProviderConfigurator().apply(gitConfig), providerTimeout)
+  }
+
+  lazy val projectManager = {
+    Try {
+      // make sure GitProvider is initialized Before creating FileProjectStore
+      // (as Git provider seem to force-pull stuff, while FileProjectStore must create a new file if one does not exists)
+      gitProvider
+      new ProjectManager(projectsDir, projectStore.get, gitProvider)
+    }
+  }
+
+  lazy val projectStore = Try(new FileProjectStore(projectsDir))
+
+  def isConfigured: Boolean = {
+    println("projectStore: ", projectStore, "projectManager:", projectManager)
+    Try(config).isSuccess && projectManager.isSuccess && projectStore.isSuccess
+  }
+}

--- a/app/views/home/projects.scala.html
+++ b/app/views/home/projects.scala.html
@@ -1,0 +1,27 @@
+<div id="projects" class="tab-pane">
+    <div id="projects_toolbar" class="row">
+        <div class="col-xs-12 no-padding tree-buttons">
+            <span id="projects_buttons" class="pull-right">
+                <button id="refresh_project_list" title="Refresh projects list" class="btn btn-default btn-xs">Refresh projects list <i class="fa fa-refresh"></i></button>
+            </span>
+        </div>
+    </div>
+    <div id="project_list">
+        <div id="project_list_header" class="row list_header">
+            <div class="name_col col-xs-3">Name</div>
+            <div class="job_col col-xs-8">Status</div>
+            <div class="action_col col-xs-1">Action</div>
+        </div>
+    </div>
+    <hr/>
+    <div style="margin-top: 50px">
+        <label>Number of lines to show: </label>
+        <input id="projects_logs_lines" type="number" value="15"/>
+    </div>
+    <div style="margin-top: 10px">
+        <label>Interval (in seconds) to refresh the current logs: </label>
+        <input id="projects_logs_refresh" type="number" value="10"/>
+    </div>
+    <div id="projects_logs_panel">
+    </div>
+</div>

--- a/app/views/projectdashboard.scala.html
+++ b/app/views/projectdashboard.scala.html
@@ -22,6 +22,9 @@
       <ul id="tabs" class="nav nav-tabs">
         <li class="active"><a href="#notebooks" data-toggle="tab">Files</a></li>
         @if(!_root_.utils.AppUtils.notebookConfig.viewer) {
+          @if(_root_.utils.SbtProjectGenUtils.isConfigured) {
+            <li><a href="#projects" data-toggle="tab">Generated SBT Projects</a></li>
+          }
           <li><a href="#running" data-toggle="tab">Running</a></li>
           <li><a href="#clusters" data-toggle="tab">Clusters</a></li>
         }
@@ -89,6 +92,11 @@
             </div>
           </div>
         </div>
+
+        @if(_root_.utils.SbtProjectGenUtils.isConfigured) {
+          @home.projects()
+        }
+
         <div id="running" class="tab-pane">
           <div id="running_toolbar" class="row">
             <div class="col-sm-8 no-padding">

--- a/build.sbt
+++ b/build.sbt
@@ -238,9 +238,45 @@ lazy val gitNotebookProvider = Project(id = "git-notebook-provider", base = file
     Extra.gitNotebookProviderSettings
   )
 
+lazy val sbtProjectGenerator = Project(id = "sbt-project-generator", base = file("modules/sbt-project-generator"))
+  .settings(
+    version := version.value
+  )
+.settings(sharedSettings: _*)
+.settings(
+  libraryDependencies += commonsIO,
+  libraryDependencies += scalaTest
+).dependsOn(
+  sbtDependencyManager,
+  sparkNotebookCore,
+  gitNotebookProvider
+) // FIXME: buildInfoKeys is now repeated
+  .settings(buildInfoSettings: _*)
+  .settings(
+    sourceGenerators in Compile <+= buildInfo,
+    buildInfoKeys :=  Seq[BuildInfoKey](
+      "sparkNotebookVersion" → SparkNotebookSimpleVersion,
+      scalaVersion,
+      sparkVersion,
+      hadoopVersion,
+      withHive,
+      jets3tVersion,
+      jlineDef,
+      sbtVersion,
+      git.formattedShaVersion,
+      BuildInfoKey.action("buildTime") {
+        val formatter = new java.text.SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy")
+        formatter.format(new java.util.Date(System.currentTimeMillis))
+      },
+      "viewer" → viewerMode
+    ),
+    buildInfoPackage := "notebook"
+  )
+
+
 lazy val sparkNotebook = project.in(file(".")).enablePlugins(play.PlayScala).enablePlugins(SbtWeb)
-  .aggregate(sparkNotebookCore, gitNotebookProvider, sbtDependencyManager, subprocess, observable, common, spark, kernel)
-  .dependsOn(sparkNotebookCore, gitNotebookProvider, subprocess, observable, common, spark, kernel)
+  .aggregate(sparkNotebookCore, gitNotebookProvider, sbtDependencyManager, sbtProjectGenerator, subprocess, observable, common, spark, kernel)
+  .dependsOn(sparkNotebookCore, gitNotebookProvider, subprocess, observable, sbtProjectGenerator, common, spark, kernel)
   .settings(sharedSettings: _*)
   .settings(
     bashScriptExtraDefines <+= (organization, version, scalaBinaryVersion, scalaVersion, sparkVersion, hadoopVersion, withHive) map { (org, v, sbv, sv, pv, hv, wh) =>
@@ -305,7 +341,7 @@ lazy val observable = Project(id = "observable", base = file("modules/observable
 lazy val common = Project(id = "common", base = file("modules/common"))
   .dependsOn(observable, sbtDependencyManager)
   .settings(
-    version  <<= (version in ThisBuild, sparkVersion) { (v,sv) => s"${v}_$sv" }
+    version  <<= (version in ThisBuild, sparkVersion) { (v,sv) => s"${sv}_${v}" }
   )
   .settings(
     libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -82,6 +82,23 @@ javaOptions in ThisBuild ++= Seq("-Xmx512M", "-XX:MaxPermSize=128M")
 
 val viewerMode = Option(sys.env.getOrElse("VIEWER_MODE", "false")).get.toBoolean
 
+val buildInfoValues = Seq[BuildInfoKey](
+  "sparkNotebookVersion" → SparkNotebookSimpleVersion,
+  scalaVersion,
+  sparkVersion,
+  hadoopVersion,
+  withHive,
+  jets3tVersion,
+  jlineDef,
+  sbtVersion,
+  git.formattedShaVersion,
+  BuildInfoKey.action("buildTime") {
+    val formatter = new java.text.SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy")
+    formatter.format(new java.util.Date(System.currentTimeMillis))
+  },
+  "viewer" → viewerMode
+)
+
 
 /*
   adding nightly build resolver like
@@ -254,22 +271,7 @@ lazy val sbtProjectGenerator = Project(id = "sbt-project-generator", base = file
   .settings(buildInfoSettings: _*)
   .settings(
     sourceGenerators in Compile <+= buildInfo,
-    buildInfoKeys :=  Seq[BuildInfoKey](
-      "sparkNotebookVersion" → SparkNotebookSimpleVersion,
-      scalaVersion,
-      sparkVersion,
-      hadoopVersion,
-      withHive,
-      jets3tVersion,
-      jlineDef,
-      sbtVersion,
-      git.formattedShaVersion,
-      BuildInfoKey.action("buildTime") {
-        val formatter = new java.text.SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy")
-        formatter.format(new java.util.Date(System.currentTimeMillis))
-      },
-      "viewer" → viewerMode
-    ),
+    buildInfoKeys :=  buildInfoValues,
     buildInfoPackage := "notebook"
   )
 
@@ -359,22 +361,7 @@ lazy val common = Project(id = "common", base = file("modules/common"))
   .settings(buildInfoSettings: _*)
   .settings(
     sourceGenerators in Compile <+= buildInfo,
-    buildInfoKeys :=  Seq[BuildInfoKey](
-                        "sparkNotebookVersion" → SparkNotebookSimpleVersion,
-                        scalaVersion,
-                        sparkVersion,
-                        hadoopVersion,
-                        withHive,
-                        jets3tVersion,
-                        jlineDef,
-                        sbtVersion,
-                        git.formattedShaVersion,
-                        BuildInfoKey.action("buildTime") {
-                          val formatter = new java.text.SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy")
-                          formatter.format(new java.util.Date(System.currentTimeMillis))
-                        },
-                        "viewer" → viewerMode
-                      ),
+    buildInfoKeys := buildInfoValues,
     buildInfoPackage := "notebook"
   )
   .settings(

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -256,3 +256,56 @@ remote-repos {
 clusters {
 
 }
+
+// ======================================
+// Config of SBT project generation below
+// ======================================
+// Mandatory:
+//sbt-project-generation {
+//  projects.dir = "/tmp/generated-sbt-projects" # dir where to store the generated sbt projects
+//  dependencies {
+//    # where to find jdk and sbt (used for compilation)
+//    jdk_home = "/Library/Java/JavaVirtualMachines/jdk1.8.0_121.jdk/Contents/Home",
+//    sbt_home = "/usr/local"
+//  }
+//}
+
+# Optional below
+//sbt-project-generation {
+  # Optional Git configuration for where to push generated artifacts
+  # ================================================================
+  // io.provider_timeout = 91 seconds
+
+  # HTTPS auth
+  //  remote = ${?SN_NOTEBOOKS_GIT_HTTPS_REPO}
+  //  authentication.username = ${?SN_NOTEBOOKS_GIT_USER}
+  # you can use a github token as a password too
+  // authentication.password = ${?SN_NOTEBOOKS_GIT_TOKEN}
+  # SSH auth:
+  //    remote = "ssh://github.com/user/repo.git"
+  //    authentication.key_file = "/Users/someuser/.ssh/id_rsa"
+  //    authentication.key_file_passphrase = "somepass"
+
+  # optional: where git files could be browsed online (e.g. github)
+  // git_www = "https://github.com/user/repo/tree/master"
+//}
+
+# optional, where to publish a generated docker image
+// sbt-project-generation.publishing.dockerRepo = "localhost:5000/canister:latest"
+
+# optional: it can publish the generated artifacts to a Maven repo
+//sbt-project-generation.publishing.artifactory {
+//    push = "http://artifactory-node:8082/artifactory/datafellas-jobs/",
+//    pull = "http://artifactory-node:8082/artifactory/list/remote-repos/",
+//    user = "some-user",
+//    password ="artifactory-password"
+//}
+
+//sbt-project-generation.code-gen {
+//  maintainer = "DF"
+//  generatedPackageBase = "com.example"
+//  mesosVersion = "0.26.0"
+//  # if not specified, it will use the versions spark-notebook was compiled with
+//  # sparkVersion = "2.0.1",
+//  #  hadoopVersion = "2.8.0"
+//}

--- a/conf/routes
+++ b/conf/routes
@@ -21,7 +21,13 @@ GET            /api/sessions/path/*path                  controllers.Application
 POST           /api/kernels/:kernelId/interrupt          controllers.Application.terminateKernel(kernelId:String)
 POST           /api/kernels/:kernelId/restart            controllers.Application.restartKernel(kernelId:String)
 
+# Sbt project generation
+POST           /adastyx/*path/generate_nb_project        controllers.GeneratedSbtProjects.generateNbProject(path:String)
+GET            /projects                                 controllers.GeneratedSbtProjects.projects()
+GET            /projects/:name/job                       controllers.GeneratedSbtProjects.projectInfo(name:String, from:Int)
+GET            /projects/:name/zip/:filename             controllers.GeneratedSbtProjects.downloadFile(name:String, filename:String)
 
+#Classic
 GET            /api/contents                             controllers.Application.contents(type:String, path:String="/")
 GET            /api/contents/                            controllers.Application.contents(type:String, path:String="/")
 GET            /api/contents/*snb/checkpoints            controllers.Application.listCheckpoints(snb:String)

--- a/modules/common/src/main/scala/notebook/util/ZipFileWriter.scala
+++ b/modules/common/src/main/scala/notebook/util/ZipFileWriter.scala
@@ -1,0 +1,35 @@
+package notebook.util
+
+import java.io.File
+
+
+class ZipFileWriter(val name: String,
+                    val tmpDir: File = { new File(sys.props("java.io.tmpdir"), "zipfile-"+System.nanoTime) }) {
+  val zipFile = new File(tmpDir, name)
+  zipFile.createNewFile
+  protected val baos = new java.io.FileOutputStream(zipFile)
+  val zip = new java.util.zip.ZipOutputStream(baos)
+
+  /**
+    * e.g.
+    * write(files = List(sameFile), prefix = "")
+    * write(files, "images/")
+    */
+  def write(files: Seq[File], prefix:String): Unit = {
+    files.foreach { f =>
+      zip.putNextEntry(new java.util.zip.ZipEntry(prefix+f.getName))
+      val in = new java.io.BufferedInputStream(new java.io.FileInputStream(f))
+      var b = in.read()
+      while (b > -1) {
+        zip.write(b)
+        b = in.read()
+      }
+      in.close()
+      zip.closeEntry()
+    }
+  }
+
+  def close(): Unit = {
+    zip.close()
+  }
+}

--- a/modules/git-notebook-provider/src/main/scala/notebook/io/GitNotebookProvider.scala
+++ b/modules/git-notebook-provider/src/main/scala/notebook/io/GitNotebookProvider.scala
@@ -112,6 +112,7 @@ class ConfigurableGitNotebookProvider(val gitProvider: GitProvider, commitMsgs: 
   }
 }
 
+// FIXME: move this as a separate class
 object ConfigUtils {
 
   implicit class ConfigOps(val config:Config) extends AnyRef {
@@ -119,6 +120,14 @@ object ConfigUtils {
     def tryGetString(path: String) : Try[String] = {
       if (config.hasPath(path)) {
         Success(config.getString(path))
+      } else {
+        Failure(new ConfigurationMissingException(path))
+      }
+    }
+
+    def tryGetPath(path: String): Try[Config] = {
+      if (config.hasPath(path)) {
+        Success(config.getConfig(path))
       } else {
         Failure(new ConfigurationMissingException(path))
       }

--- a/modules/sbt-project-generator/README.md
+++ b/modules/sbt-project-generator/README.md
@@ -1,0 +1,61 @@
+# Adalog-deploy-generator
+
+This is a library which can generate an SBT project from a [Spark Notebook](https://github.com/andypetrella/spark-notebook/).
+
+The code is still experimental.
+
+# How to enable it?
+
+Uncomment and adapt the mandatory `sbt-project-generation` section in `conf/application.conf` file. 
+
+```conf
+sbt-project-generation {
+  projects.dir = "/tmp/generated-sbt-projects" # dir where to store the generated sbt projects
+  dependencies {
+    # where to find jdk and sbt (used for compilation)
+    jdk_home = "/Library/Java/JavaVirtualMachines/jdk1.8.0_121.jdk/Contents/Home",
+    sbt_home = "/usr/local"
+  }
+}
+```
+
+You may also optionally:
+- set up the generated code to be uploaded to a Git repo (beware it does a force push each time!).
+  * [More details on setting up Git auth here](/modules/git-notebook-provider/README.md)
+- set up the artifactory to automatically publish to
+
+
+# What does it do?
+It generates a project in `/tmp/generated-projects-dir/a-notebook-name` composed of
+
+* `build.sbt`
+* `src/scala/App.scala`
+* ...
+
+Now you can check if it really compiles:
+```
+sbt compile
+```
+P.S. you may need to take care or small differences between Scala REPL and compiled code, e.g.
+do not define same name multiple times
+
+
+
+# What you can do with the generated code ?
+
+```bash
+# Go to a folder with generated code
+cd /tmp/generated-projects-dir/a-notebook-name
+sbt run
+# or also:
+sbt package # create a single uberjar including all dependencies JARs
+sbt packageBin  # create a .zip archive
+sbt debian:packageBin  # for creating a .deb
+sbt publish # publish to a Maven repository
+
+# or even publish to docker:
+sbt docker:publishLocal
+sbt docker:publish some-repo/project-name:some-version
+```
+
+This will compile and run the project, which creates the spark context and runs the code included in the notebook.

--- a/modules/sbt-project-generator/src/main/scala-2.10/com/datafellas/g3nerator/SbtDependencyResolver.scala
+++ b/modules/sbt-project-generator/src/main/scala-2.10/com/datafellas/g3nerator/SbtDependencyResolver.scala
@@ -1,0 +1,70 @@
+package com.datafellas.g3nerator
+
+import java.io.File
+
+import com.datafellas.g3nerator.model.DependencyConfig
+import com.datafellas.utils.{Deps, CustomResolvers}
+import notebook.Notebook
+import sbt.{MavenRepository, Resolver}
+
+import scala.util.Try
+
+
+class SbtDependencyResolver(snb: Notebook, sparkVersion: String, projectDependencyConfig: DependencyConfig) {
+  def libraryDependenciesCode(customDeps: List[String]): String = {
+    val (includes, excludes) = Deps.parse(customDeps.mkString("\n"), sparkVersion)
+    val eee = excludes.map { e =>
+      if (e.name == "*") {
+        s""" ExclusionRule( "${e.organization}" ) """
+      } else {
+        s""" ExclusionRule( "${e.organization}", "${e.name}" ) """
+      }
+    }.mkString(",\n")
+    val deps = includes.map { i =>
+      s"""|
+          |libraryDependencies += "${i.organization}" % "${i.name}" % "${i.revision}" excludeAll(
+          |$eee
+          |)
+          |
+          |
+    """.stripMargin
+    }.mkString("\n")
+    deps
+  }
+
+  def resolveJars(customDeps: List[String], repo: File): Try[List[String]] = {
+    Deps.script(customDeps.mkString("\n"), resolvers, repo, sparkVersion)
+  }
+
+  lazy val resolvers: List[Resolver] = {
+    val mavenLocal = Resolver.mavenLocal
+    val mavenReleases = sbt.DefaultMavenRepository
+    val typesafeReleases = Resolver.typesafeIvyRepo("releases")
+    val jCenterReleases = Resolver.jcenterRepo
+    val sonatypeReleases = Resolver.sonatypeRepo("releases")
+    val spReleases = new MavenRepository("spark-packages", projectDependencyConfig.resolverBintraySparkPackagesMvn)
+    val defaults = mavenLocal :: mavenReleases :: spReleases :: typesafeReleases :: jCenterReleases :: sonatypeReleases :: Nil
+    snb.metadata.get.customRepos.getOrElse(List.empty[String]).map(CustomResolvers.fromString).map(_._2) ::: defaults
+  }
+
+  def resolversCode: String = {
+    val resv = resolvers.map { r =>
+      val root = r.getClass.getMethods.find(_.getName == "root")
+      root match {
+        case Some(m) => s""" "${r.name}" at "${m.invoke(r)}" """
+        case None => r match {
+          case r:sbt.URLRepository =>
+            val patterns = s"""new sbt.Patterns(
+              ${r.patterns.ivyPatterns.map(s => "\""+s+"\"").mkString("List(", ",", ")")},
+              ${r.patterns.artifactPatterns.map(s => "\""+s+"\"").mkString("List(", ",", ")")},
+              ${r.patterns.isMavenCompatible}
+            )
+            """
+            s""" new sbt.URLRepository("${r.name}", $patterns) """
+          case _ => "UNKNOWN repo →→→ " + r
+        }
+      }
+    }
+    resv.mkString("Seq(\n", ",\n", ")")
+  }
+}

--- a/modules/sbt-project-generator/src/main/scala-2.11/com/datafellas/g3nerator/SbtDependencyResolver.scala
+++ b/modules/sbt-project-generator/src/main/scala-2.11/com/datafellas/g3nerator/SbtDependencyResolver.scala
@@ -1,0 +1,23 @@
+package com.datafellas.g3nerator
+
+import java.io.File
+
+import com.datafellas.g3nerator.model.DependencyConfig
+import notebook.Notebook
+
+import scala.util.Try
+
+// FIXME: to be implemented based on scala 2.10
+class SbtDependencyResolver(snb: Notebook, sparkVersion: String, projectDependencyConfig: DependencyConfig) {
+  def libraryDependenciesCode(customDeps: List[String]): String = {
+    ""
+  }
+
+  def resolveJars(customDeps: List[String], repo: File): Try[List[String]] = {
+    Try(List())
+  }
+
+  def resolversCode: String = {
+    "Seq()"
+  }
+}

--- a/modules/sbt-project-generator/src/main/scala/com/datafellas/g3nerator/FileUtils.scala
+++ b/modules/sbt-project-generator/src/main/scala/com/datafellas/g3nerator/FileUtils.scala
@@ -1,0 +1,37 @@
+package com.datafellas.g3nerator
+
+import java.io.{File, FileWriter, PrintWriter}
+
+object FileUtils {
+  def atS(f:String, p:String):File = at(new File(f), p)
+
+  implicit class DirOps(val dir:File) extends AnyVal {
+    def /(path : String) : File = at(dir, path)
+    def apply(filename: String) : File = new File(dir, filename)
+  }
+
+  def at(f:File, p:String):File = {
+    p.split("/").toList match {
+      case Nil | List("") =>
+        f.mkdirs
+        f
+      case x::rest =>
+        at(new File(f, x), rest.mkString("/"))
+    }
+  }
+
+  sealed trait AppendMode {
+    def legacyValue: Boolean
+  }
+  case class AppendValue(legacyValue:Boolean) extends AppendMode
+  object Append extends AppendValue (true)
+  object NoAppend extends AppendValue (false)
+
+  def writeTo(t:File, appendMode: AppendMode = NoAppend)(s:String) = {
+    val w = new PrintWriter(new FileWriter(t, appendMode.legacyValue))
+    w.println(s)
+    w.flush()
+    w.close()
+  }
+
+}

--- a/modules/sbt-project-generator/src/main/scala/com/datafellas/g3nerator/Job.scala
+++ b/modules/sbt-project-generator/src/main/scala/com/datafellas/g3nerator/Job.scala
@@ -524,11 +524,11 @@ class Job( val project: Project,
     val jars: Try[List[String]] = nbDepencyResolver.resolveJars(snb.metadata.get.customDeps.getOrElse(Nil), repo)
     LOG.info("Downloaded deps for job:\n" + jars)
     val libJars = jars.get.map { jar =>
-//      import scalax.io._
-//      import Resource._
-      val name = new File(jar).getName
-      // FIXME: fromFile(jar) copyDataTo fromFile(`root/spark-lib`(name))
-      name
+      val srcFile = new File(jar)
+      val destDir = `root/spark-lib`
+      val preserveFileDate = false
+      org.apache.commons.io.FileUtils.copyFileToDirectory(srcFile: File, destDir, preserveFileDate)
+      srcFile.getName
     }
     libJars
   }

--- a/modules/sbt-project-generator/src/main/scala/com/datafellas/g3nerator/Job.scala
+++ b/modules/sbt-project-generator/src/main/scala/com/datafellas/g3nerator/Job.scala
@@ -1,0 +1,838 @@
+package com.datafellas.g3nerator
+
+import java.io.File
+
+import play.api.libs.json._
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext
+import com.datafellas.g3nerator.model._
+import com.datafellas.g3nerator.model.Project
+import com.datafellas.g3nerator.FileUtils._
+import com.datafellas.utils._
+import notebook.Notebook
+import com.datafellas.g3nerator.model.Artifact.State._
+import notebook.NBSerializer.CodeCell
+
+import scala.util.{Success, Try}
+
+class Job( val project: Project,
+           val repo: File,
+           val root: File ) {
+
+  import Job._
+  //[gm!] for this to work, notebook metadata must be mandatory
+  private[this] val snb: Notebook = project.snb
+  val metadata = snb.metadata.get
+
+  private[this] val LOG = org.slf4j.LoggerFactory.getLogger(getClass.getSimpleName)
+
+  val materializer = new FileSystemMaterializer
+
+  val snConfig = metadata.sparkNotebook.getOrElse(Map.empty)
+  // Always use version with which SN is built for now
+  // def pickVersion(key: String, snVersion: String) = snConfig.getOrElse(key, snVersion)
+  def pickVersion(key: String, snBuildInfoVersion: String) = snBuildInfoVersion
+
+  val scalaVersion = pickVersion("scalaVersion", notebook.BuildInfo.scalaVersion)
+  val majorScalaVersion = scalaVersion.split("\\.").take(2).mkString(".")
+  val sparkNotebookVersion = pickVersion("sparkNotebookVersion", notebook.BuildInfo.sparkNotebookVersion)
+  val sparkVersion = pickVersion("xSparkVersion", notebook.BuildInfo.xSparkVersion)
+  val hadoopVersion = pickVersion("xHadoopVersion", notebook.BuildInfo.xHadoopVersion)
+
+  val prodSparkVersion = project.productionConfig.map(_.sparkVersion).getOrElse(sparkVersion)
+  val prodHadoopVersion = project.productionConfig.map(_.hadoopVersion).getOrElse(hadoopVersion)
+  val customDeps = metadata.customDeps.getOrElse(Nil) ::: List(
+    """- com.typesafe.akka % _ % _""",
+    """- com.google.guava % _ % _"""
+  )
+  val uuid = snb.metadata.map(_.id).getOrElse("id-not-found")
+  val notebookName = snb.normalizedName
+
+  val library = Library(notebookName, project.config.pkg, project.config.version, majorScalaVersion)
+
+  lazy val nbDepencyResolver = new SbtDependencyResolver(snb, sparkVersion, project.dependencyConfig)
+
+  //[gm!] looks like notebook raw content must be mandatory
+  lazy val longLived = snb.rawContent.exists(_.contains("StreamingContext"))
+
+  // build artifacts
+  lazy val `root/out` = root("out")
+  lazy val `root/compile.statuscode` = root("compile.statuscode")
+  lazy val `root/gen.sh` = root("gen.sh")
+  lazy val `root/build.sbt` = root("build.sbt")
+  lazy val `root/project`= root / "project"
+  lazy val `root/project/build.properties` = `root/project`("build.properties")
+  lazy val `root/project/plugins.sbt` = `root/project`("plugins.sbt")
+  // code/config artifacts
+  lazy val `root/src` = root / "src"
+  lazy val `root/src/main/scala` = root / "src/main/scala"
+  lazy val `root/src/main/scala/App.scala` = `root/src/main/scala`("App.scala")
+  lazy val `root/src/main/scala/Classes.scala` = `root/src/main/scala`("Classes.scala")
+  lazy val `root/src/main/resources` = root/ "src/main/resources/"
+  lazy val `root/src/main/resources/notebook.snb` = `root/src/main/resources`("notebook.snb")
+  lazy val `root/src/main/resources/application.conf` = `root/src/main/resources`("application.conf")
+  lazy val `root/target` = root / "target"
+  lazy val `root/target/debian_pkg.deb` = `root/target`(library.debianPackage)
+  // mocked widgets / charts
+  lazy val `root/src/main/scala/MockedCharts.scala` =  `root/src/main/scala`("MockedCharts.scala")
+
+  // spark artifacts
+  lazy val `root/spark-lib` = root / "spark-lib"
+  lazy val `root/sources.zip` = root("sources.zip")
+
+  // job content
+  lazy val build = buildSBT()
+  lazy val createSparkContextCode = buildCreateSparkContextCode()
+  lazy val mainCode = buildMainCode()
+  lazy val classCode = buildClasses()
+
+  lazy val sourceArchiveFiles = Seq(
+    `root/build.sbt`,
+    `root/project/build.properties`,
+    `root/project/plugins.sbt`,
+    `root/spark-lib`,
+    //  `root/target`(library.jarTargetPath),
+    `root/src`
+  )
+  lazy val artifactsToClean = sourceArchiveFiles ++ Seq(
+    `root/compile.statuscode`,
+    `root/sources.zip`,
+    `root/out` // clean old logs
+  )
+
+
+  private var generated = false
+  def isGenerated = generated
+
+  def artifacts(local:Boolean): List[Artifact[Unmaterialized]] = {
+    LOG.info("Generating job artifacts")
+    val jobArtifacts = List(Artifact(`root/project/plugins.sbt`, Job.Build.Sbt.plugins),
+      Artifact(`root/project/build.properties`, Job.Build.properties),
+      Artifact(`root/build.sbt`, build),
+      Artifact(`root/src/main/scala/App.scala`, app()),
+      Artifact(`root/src/main/scala/Classes.scala`, classes()),
+      Artifact(`root/src/main/scala/MockedCharts.scala`, mockedChartsCode),
+      Artifact(`root/src/main/resources/application.conf`, appConfig()),
+      Artifact(`root/gen.sh`, genScript(local))
+    )
+    snb.rawContent.foldLeft(jobArtifacts)((artifacts, raw) =>
+      Artifact(`root/src/main/resources/notebook.snb`, raw) :: artifacts)
+  }
+
+  def materialize(artifacts: List[Artifact[Unmaterialized]]): List[Try[Artifact[Materialized]]] = {
+    artifacts.map(artifact => artifact.materialize(materializer))
+  }
+
+  def cleanOldArtifacts(): Unit = {
+    import org.apache.commons.io.FileUtils
+    artifactsToClean.foreach(FileUtils.deleteQuietly)
+  }
+
+  def writeSourcesZip(): Unit = {
+    println(s"zip file: ${`root/sources.zip`}")
+    println(s"zip contents: ${sourceArchiveFiles}")
+
+    val tmpFileName = "sources.zip.tmp"
+    val tmpFile = root(tmpFileName)
+    tmpFile.exists() && tmpFile.delete()
+
+    ZipArchiveUtil.createArchiveRecursively(
+      rootPath = root.getAbsolutePath,
+      inputFiles = sourceArchiveFiles.filter(_.exists).map(_.getAbsolutePath),
+      outputFilename = tmpFileName
+    )
+    tmpFile.renameTo(`root/sources.zip`)
+  }
+
+  def generateOnly(local: Boolean): Try[Unit] = {
+    val artfs = artifacts(local)
+    val materializedArtifacts = materialize(artfs)
+    materializedArtifacts.foldLeft(Success(()):Try[Unit]){(res, artf)=> res.flatMap(e=> artf.map(_=>()))}
+  }
+
+  def run(genScript: File, output: File): Future[Unit] = {
+    genScript.setExecutable(true)
+    import sys.process._
+    import ExecutionContext.Implicits.global
+    Future {
+      s"bash ${genScript.getAbsolutePath}" #>> output lines_! ProcessLogger(out => LOG.info(notebookName + "::" + out), err => LOG.error(err))
+      ()
+    }
+  }
+
+  // This needs another refactoring round for error handling
+  def publish(local: Boolean): Future[Unit] =  {
+    cleanOldArtifacts()
+    val artfs = artifacts(local)
+    val materializedArtifacts = materialize(artfs)
+    val maybeBuildScript = materializedArtifacts.collect{
+      case Success(artf) if artf.fd == `root/gen.sh` => artf.fd
+    }.headOption
+    val buildResult = maybeBuildScript.map {script => run(script, `root/out`)}
+      .getOrElse(Future.failed(new RuntimeException("Could not generate gen script")))
+
+    import ExecutionContext.Implicits.global
+    buildResult.andThen { case _ => writeSourcesZip() }
+  }
+
+
+  def indentLines(str: String, nChars: Int = 2) = {
+    val indent = " " * nChars
+    str
+      .split("\n")
+      .map(indent + _)
+      .mkString("\n")
+      .trim
+  }
+
+  def app() = {
+    s"""|
+    |package ${library.classPkg}
+    |
+    |object Main {
+    |
+    |  def main(args:Array[String]):Unit = {
+    |    // spark context
+    |    ${indentLines(createSparkContextCode, nChars = 4)}
+    |
+    |    // main code
+    |    ${indentLines(mainCode, nChars = 4)}
+    |  }
+    |}
+    |""".stripMargin
+  }
+
+  def classes() = {
+    s"""|
+    |package ${library.classPkg}
+    |
+    |$classCode
+    |
+    |""".stripMargin
+  }
+
+  def genScript(local: Boolean) = {
+    val rootPath = root.getAbsolutePath
+
+    //    val publishDocker = if (Option(project.config.dockerRepo).getOrElse("").trim.nonEmpty) {
+    //      s"""
+    //         |
+    //         |echo "publishing docker"
+    //         |docker push ${project.config.dockerRepo}/${DebianName(notebookName).name}:${project.config.version}
+    //         |
+    //         |""".stripMargin
+    //    }
+    //    else ""
+
+    val sbt = s"${project.dependencyConfig.sbtHome}/bin/sbt"
+
+    // val publishCmd = s"publish${project.dependencyConfig.artifactory.map(_ => "").getOrElse("Local")}"
+    val publishCmd = project.dependencyConfig.artifactory match {
+      case Some(_) => "publish"
+      case None => "package"
+    }
+
+    val publishJarCmd =
+      s"""
+         |echo "compiling/publishing a jar"
+         |$sbt -Dspark.version=${prodSparkVersion} -Dhadoop.version=${prodHadoopVersion} clean $publishCmd
+         |echo "$$?" > compile.statuscode
+       """.stripMargin
+
+    val pkgPath = `root/target/debian_pkg.deb`.getAbsolutePath
+    val packageDebCmd = ""
+    //      s"""
+    //         |echo "building debian"
+    //         |$sbt -Dspark.version=${prodSparkVersion} -Dhadoop.version=${prodHadoopVersion} debian:packageBin
+    //         |echo "package: $pkgPath "
+    //       """.stripMargin
+
+    s"""|
+        |#!/bin/bash
+        |
+        |echo "Start gen.sh"
+        |echo $$(date)
+        |echo "At directory `pwd`"
+        |
+        |export JAVA_HOME=${project.dependencyConfig.jdkHome}
+        |export JDK_HOME=${project.dependencyConfig.jdkHome}
+        |export PATH=${project.dependencyConfig.sbtHome}/bin:${project.dependencyConfig.jdkHome}/bin:$$PATH
+        |
+        |echo "cd ${root.getAbsolutePath}"
+        |
+        |cd ${root.getAbsolutePath}
+        |
+        |${publishJarCmd}
+        |
+        |${packageDebCmd}
+        ||
+        |echo "End gen.sh"
+        |echo $$(date)
+        |
+      |""".stripMargin.trim
+  }
+
+  def buildSBT() = {
+    val deps = nbDepencyResolver.libraryDependenciesCode(customDeps)
+    val customResolversCode = nbDepencyResolver.resolversCode
+
+    val addJvmArgs = snb.metadata.get.customArgs.getOrElse(Nil).map { a =>
+      s"""bashScriptExtraDefines += \"\"\"addJava "$a"\"\"\""""
+    }.mkString("\n\n")
+
+    val artifactoryPublish:String = project.dependencyConfig.artifactory.map { case ((pull, push), credOpt) =>
+      val cred = credOpt.map { case (user, password) =>
+        val host = new java.net.URI(push).getHost
+        s"""credentials += Credentials("Artifactory Realm", "$host", "$user", "$password")"""
+      }.getOrElse("")
+
+      val addAssembly = project.productionConfig.map { _ =>
+        "addArtifact(artifact in (Compile, assembly), assembly).settings"
+      }.getOrElse("")
+
+      val publish = s"""|
+      |$addAssembly
+      |
+      |publishTo := Some("Artifactory PUSH Realm" at "$push")
+      |
+      |publishMavenStyle := true
+      |
+      |$cred
+      |
+      |""".stripMargin.trim
+
+      publish
+    }.getOrElse("")
+
+    val artifactoryResolver:String = project.dependencyConfig.artifactory.map { case ((pull, push), _) =>
+      s"""resolvers += "Adastyx PULL Artifactory" at "${pull}""""
+    }.getOrElse("")
+
+    val providedArtifact = "% \"provided\""
+
+    val sparkProvided = ""
+    val hadoopProvided = ""
+
+    s"""|
+    |organization := "${library.group}"
+    |
+    |name := "${library.name}"
+    |
+    |version := "${library.version}"
+    |// append scala version to artifact name(s)
+    |crossPaths := true
+    |
+    |scalaVersion := "${scalaVersion}"
+    |
+    |maintainer := "${project.config.maintainer}" //Docker
+    |
+    |resolvers ++= ${customResolversCode}
+    |
+    |net.virtualvoid.sbt.graph.Plugin.graphSettings
+    |
+    |enablePlugins(UniversalPlugin)
+    |
+    |enablePlugins(DockerPlugin)
+    |
+    |enablePlugins(JavaAppPackaging)
+    |
+    |import com.typesafe.sbt.SbtNativePackager.autoImport.NativePackagerHelper._
+    |
+    |import com.typesafe.sbt.packager.docker._
+    |
+    |dockerBaseImage := "${project.dependencyConfig.dockerBaseImage}"
+    |
+    |dockerExposedPorts := Seq(9000, 9443)
+    |
+    |daemonUser in Docker := "root"
+    |
+    |packageName in Docker := "${library.classPkg}"
+    |
+    |mappings in Docker ++= directory("spark-lib")
+    |
+    |mappings in Universal ++= directory("spark-lib")
+    |
+    |resolvers += Resolver.mavenLocal
+    |
+    |resolvers += Resolver.typesafeRepo("releases")
+    |
+    |resolvers += "cloudera" at "${project.dependencyConfig.resolverCloudera}"
+    |
+    |$artifactoryResolver
+    |
+    |credentials += Credentials(Path.userHome / ".bintray" / ".credentials")
+    |
+    |resolvers += Resolver.url("bintray-data-fellas-maven", url("${project.dependencyConfig.resolverBintrayDataFellasMvn}"))(Resolver.ivyStylePatterns)
+    |
+    |dockerCommands ++= Seq(Cmd("ENV", "SPARK_HOME \\"\\""))
+    |
+    |dockerRepository := Some("${project.config.dockerRepo}") //Docker
+    |
+    |enablePlugins(DebianPlugin)
+    |
+    |name in Debian := "${DebianName(notebookName).name}"
+    |
+    |maintainer in Debian := "Data Fellas"
+    |
+    |packageSummary in Debian := "Data Fellas Generated Job"
+    |
+    |packageDescription := "Generated Job by Spark-notebook"
+    |
+    |debianPackageDependencies in Debian += "java8-runtime-headless"
+    |
+    |serverLoading in Debian := com.typesafe.sbt.packager.archetypes.ServerLoader.Upstart
+    |
+    |daemonUser in Linux := "root"
+    |
+    |daemonGroup in Linux := "root"
+    |
+    |bashScriptExtraDefines += "export SPARK_HOME=\\"\\""
+    |
+    |
+    |$addJvmArgs
+    |
+    |val sparkVersion  = sys.env.get("SPARK_VERSION") .orElse(sys.props.get("spark.version")) .getOrElse("$sparkVersion")
+    |
+    |val hadoopVersion = sys.env.get("HADOOP_VERSION").orElse(sys.props.get("hadoop.version")).getOrElse("$hadoopVersion")
+    |
+    |// TODO: needed only if you use some of spark-notebook code
+    |// (most likely you don't want to use this, otherwise  you'd need to publishLocal the SN libs)
+    |// libraryDependencies += "io.kensu" %% "common" % (sparkVersion + "_${sparkNotebookVersion}") excludeAll(
+    |//    ExclusionRule("org.apache.hadoop"),
+    |//    ExclusionRule("org.apache.spark")
+    |// )
+    |
+    |libraryDependencies += "com.typesafe" % "config" % "1.3.1"
+    |
+    |// you might not need all of the Spark jars below
+    |libraryDependencies += "org.apache.spark" %% "spark-core" % sparkVersion $sparkProvided excludeAll(
+    |    ExclusionRule("org.apache.hadoop"),
+    |    ExclusionRule("org.apache.ivy", "ivy")
+    |  )
+    |
+    |libraryDependencies += "org.apache.spark" %% "spark-mllib" % sparkVersion $sparkProvided excludeAll(
+    |    ExclusionRule("org.apache.hadoop"),
+    |    ExclusionRule("org.apache.ivy", "ivy")
+    |  )
+    |
+    |libraryDependencies += "org.apache.spark" %% "spark-sql" % sparkVersion $sparkProvided excludeAll(
+    |  ExclusionRule("org.apache.hadoop")
+    |)
+    |
+    |libraryDependencies += "org.apache.spark" %% "spark-yarn" % sparkVersion $sparkProvided excludeAll(
+    |  ExclusionRule("org.apache.hadoop"),
+    |  ExclusionRule("org.apache.ivy", "ivy")
+    |  )
+    |
+    |libraryDependencies += "org.apache.spark" %% "spark-hive" % sparkVersion  $sparkProvided excludeAll(
+    |    ExclusionRule("org.apache.hadoop"),
+    |    ExclusionRule("org.apache.ivy", "ivy"),
+    |    ExclusionRule("javax.servlet", "servlet-api"),
+    |    ExclusionRule("org.mortbay.jetty", "servlet-api")
+    |  )
+    |
+    |libraryDependencies += "org.apache.hadoop" % "hadoop-client" % hadoopVersion  $hadoopProvided excludeAll(
+    |    ExclusionRule("org.apache.commons", "commons-exec"),
+    |    ExclusionRule("commons-codec", "commons-codec"),
+    |    ExclusionRule("com.google.guava", "guava"),
+    |    ExclusionRule("javax.servlet")
+    |  )
+    |
+    |libraryDependencies += "org.apache.hadoop" % "hadoop-yarn-server-web-proxy" % hadoopVersion  $hadoopProvided excludeAll(
+    |      ExclusionRule("org.apache.commons", "commons-exec"),
+    |      ExclusionRule("commons-codec", "commons-codec"),
+    |      ExclusionRule("com.google.guava", "guava"),
+    |      ExclusionRule("javax.servlet")
+    |  )
+    |
+    |libraryDependencies += "net.java.dev.jets3t" % "jets3t" % "0.9.0" force()
+    |
+    |libraryDependencies += "com.google.guava" % "guava" % "16.0.1" force()
+    |
+    |$deps
+    |
+    |//asssembly
+    |// skip test during assembly
+    |test in assembly := {}
+    |
+    |//main class
+    |mainClass in assembly := Some("${project.config.pkg}.Main")
+    |
+    |artifact in (Compile, assembly) ~= { art =>
+    |  art.copy(`classifier` = Some("assembly"))
+    |}
+    |
+    |$artifactoryPublish
+    |
+    |// merging files... specially application.conf!
+    |assemblyMergeStrategy in assembly := {
+    |  case PathList("javax", "servlet",          xs @ _*) => MergeStrategy.first
+    |  case PathList("org",   "apache",           xs @ _*) => MergeStrategy.first
+    |  case PathList("org",   "fusesource",       xs @ _*) => MergeStrategy.first
+    |  case PathList("org",   "slf4j",            xs @ _*) => MergeStrategy.first
+    |  case PathList("com",   "google",           xs @ _*) => MergeStrategy.first
+    |  case PathList("play",  "core",             xs @ _*) => MergeStrategy.first
+    |  case PathList("javax", "xml",              xs @ _*) => MergeStrategy.first
+    |  case PathList("com",   "esotericsoftware", xs @ _*) => MergeStrategy.first
+    |  case PathList("xsbt",                      xs @ _*) => MergeStrategy.first
+    |  case PathList("META-INF", "MANIFEST.MF"           ) => MergeStrategy.discard
+    |  case PathList("META-INF",                  xs @ _*) => MergeStrategy.first
+    |  case "application.conf"                             => MergeStrategy.concat
+    |  case "module.properties"                             => MergeStrategy.first
+    |  case PathList(ps @ _*) if ps.last endsWith ".html"  => MergeStrategy.discard
+    |  case PathList(ps @ _*) if ps.last endsWith ".thrift"  =>  MergeStrategy.first
+    |  case PathList(ps @ _*) if ps.last endsWith ".xml"  =>  MergeStrategy.first
+    |  case x =>
+    |    val oldStrategy = (assemblyMergeStrategy in assembly).value
+    |    oldStrategy(x)
+    |}
+    |
+    |aggregate in update := false
+    |
+    |updateOptions := updateOptions.value.withCachedResolution(true)
+    |
+    |""".stripMargin
+  }
+
+  def appConfig(): String = {
+    val fromMD = snb.metadata.flatMap { meta =>
+      val customSparkConf = meta.customSparkConf.flatMap { customConf =>
+        Reads.map[String].reads(customConf).asOpt
+      }.map { kvMap =>
+        kvMap.map { case (k, v) =>
+          val value = v.toString.replaceAll("\"", "\\\\\"")
+          s""" $k : "$value"  """
+        }.mkString("\n")
+      }
+
+      val customVars = meta.customVars.map { customVars =>
+        customVars.map { case (k, v) => s""" $NotebookVarsPrefix.$k : "$v" """ }.mkString("\n")
+      }
+
+      val config = List(customSparkConf, customVars).flatten.mkString("\n")
+      if (config.isEmpty) None else Some(config)
+    }
+
+    List(fromMD, Some("#-- End Config --")).flatten.mkString("\n")
+  }
+
+  def downloadCustomDependencies(): List[String] = {
+    // copy all customDeps to the spark-lib directory
+    // FIXME: makes sense for locally installed dependencies, but it would be better to leave the regular custom dependencies for SBT
+    LOG.info("Custom deps to resolve and download:" + snb.metadata.get.customDeps.getOrElse(Nil))
+    val jars: Try[List[String]] = nbDepencyResolver.resolveJars(snb.metadata.get.customDeps.getOrElse(Nil), repo)
+    LOG.info("Downloaded deps for job:\n" + jars)
+    val libJars = jars.get.map { jar =>
+//      import scalax.io._
+//      import Resource._
+      val name = new File(jar).getName
+      // FIXME: fromFile(jar) copyDataTo fromFile(`root/spark-lib`(name))
+      name
+    }
+    libJars
+  }
+
+  def executorJarsCode(downloadedJars: Seq[String]) = {
+    val downloadedJarsArray = downloadedJars.map { j => s""" "$j" """ }.mkString("Array[String](", ",", ")")
+
+    // FIXME: this is valid only for 'debian' & 'dist/stage/package' builds only (!)
+    val currentProjectJarsArray = s"""Array("lib/${library.jarInDeb}", "${library.jarInTargetPath}")"""
+
+    s"""|
+        |def setExecutorJars() = {
+        |  val currentProjectJars = $currentProjectJarsArray.map{j => new java.io.File(j)}.filter(_.exists()).map(_.getAbsolutePath)
+        |  val sparkLibDir = new java.io.File("spark-lib")
+        |  val fromProjectJars = $downloadedJarsArray.map{j => new java.io.File(sparkLibDir, j).getAbsolutePath}
+        |  val jarsArray = (sparkConf.get("spark.jars", "").split(",").toArray ++ currentProjectJars ++ fromProjectJars).distinct.filter(!_.isEmpty)
+        |  println("Add Jars: \\n" + jarsArray.mkString("\\n"))
+        |  sparkConf.setJars(jarsArray)
+        |}
+        |""".stripMargin
+  }
+
+  def buildCreateSparkContextCode() = {
+    val downloadedJars = downloadCustomDependencies()
+
+    s"""|
+    |import org.apache.spark.{SparkContext, SparkConf}
+    |import org.apache.spark.SparkContext._
+    |import org.apache.spark.rdd._
+    |import org.apache.spark.sql._
+    |import org.apache.spark.sql.functions._
+    |import com.typesafe.config._
+    |import scala.collection.JavaConverters._
+    |import scala.util.Try
+    |
+    |
+    |// Spark notebook widgets (can be removed if you do not use them)
+    |// Dummy implementation of the most common ones (to avoid shipping 80+ MB of spark-notebook jars)
+    |import notebook.front.widgets.charts._
+    |import notebook.front.widgets.charts.MockedCharts._
+    |
+    |// Create spark configuration holder
+    |val sparkConf = new SparkConf()
+    |
+    |// Set configuration
+    |val config = ConfigFactory.load()
+    |val sparkConfig = Try(config.getConfig("spark"))
+    |  .getOrElse(com.typesafe.config.ConfigFactory.empty)
+    |  .atPath("spark").entrySet.asScala.map(e => e.getKey -> config.getString(e.getKey))
+    |
+    |sparkConf.setAll(sparkConfig)
+    |
+    |sparkConf.setMaster(sparkConf.get("spark.master", "local[*]"))
+    |sparkConf.set("spark.app.name", sparkConf.get("spark.app.name", "${notebookName}"))
+    |
+    |// Distribute the jars to executors, so this do not require a separate spark installation
+    |// This is needed only if not using spark-submit (comment otherwise)
+    |${executorJarsCode(downloadedJars)}
+    |setExecutorJars()
+    |
+    |// Create Spark Session / Spark Context
+    |val sparkSession = SparkSession.builder().config(sparkConf).getOrCreate
+    |val sparkContext = sparkSession.sparkContext
+    |println("SparkConf used:" + sparkContext.getConf.toDebugString)
+    |
+    |// aliases
+    |val sc = sparkContext
+    |val ss = sparkSession
+    |import ss.implicits._
+    |
+    |""".stripMargin
+  }
+
+  def loadCustomVars() : String = {
+    val customVars = snb.metadata.flatMap(_.customVars)
+      .map { vars =>
+        val customVars = vars.map { case (k, v) => s"""  val $k = customVars.getString("$k") """ }.mkString("// custom variables\n", "\n", "")
+        s"""
+           |val customVars = config.getConfig("$NotebookVarsPrefix")
+           |$customVars
+           |
+     """.stripMargin
+      }
+    customVars.getOrElse("// no custom variables ")
+  }
+
+  val stopContext = """|
+    |sparkContext.stop
+    |""".stripMargin
+
+  val isClassDefinition: String => Boolean = str => str.split("\n").exists { line =>
+    val trimmed = line.trim
+    trimmed.startsWith("class") || trimmed.startsWith("case class")
+  }
+
+  implicit class CodeCellImplicits(cell: CodeCell){
+    def isInterpretedCell: Boolean = cell.source.trim.startsWith(":")
+    def isRegularCodeCell: Boolean = {
+      Seq(None, Some("scala")).contains(cell.language) &&
+        // simply ignore fancy interpreted cells for now
+        !cell.isInterpretedCell
+    }
+  }
+
+  def buildMainCode():String = {
+    val imports = snb.metadata.get.customImports.getOrElse(Nil).mkString("\n")
+    val uuid = snb.metadata.map(_.id).getOrElse("id-not-found")
+    val customVars = loadCustomVars()
+    val code = snb.cells.map { cells =>
+      val cs = cells.collect {
+        case cell : notebook.NBSerializer.CodeCell if cell.isRegularCodeCell && !isClassDefinition(cell.source)=>
+            cell.metadata.id → cell.source
+      }
+      val code = cs.map{ case (id, code) => id → code.split("\n").map { s => s"  $s" }.mkString("\n") }
+                  .map{ case (id, code) => (s"\n\n  /* -- Code Cell: ${id} -- */ \n\n$code") }
+                  .mkString("\n/****************/\n").trim
+      code
+    }.getOrElse("//NO CELLS!")
+
+
+    List(imports, customVars, code, stopContext).mkString("\n")
+  }
+
+  def buildClasses() : String = {
+      val imports = snb.metadata.get.customImports.getOrElse(Nil).mkString("\n")
+      val code = snb.cells.map { cells =>
+        val cs = cells.collect {
+          case cell : notebook.NBSerializer.CodeCell if cell.isRegularCodeCell && isClassDefinition(cell.source)=>
+            cell.metadata.id → cell.source
+        }
+        val code = cs.map{ case (id, code) => (id, code.split("\n").map {s => "  " + s}.mkString("\n")) }
+          .map{ case (id, code) => (s"\n\n  /* -- Code Cell: ${id} -- */ \n\n$code") }
+          .mkString("\n/****************/\n").trim
+        code
+      }.getOrElse("//NO CELLS!")
+      val separator = "  //---//"
+      List(imports, separator, code).mkString("\n")
+  }
+
+  def mockedChartsCode : String = {
+    """
+      |package notebook.front.widgets.charts
+      |
+      |import notebook.front.widgets.charts.MockedCharts.DEFAULT_MAX_POINTS
+      |
+      |object MockedCharts {
+      |  val DEFAULT_MAX_POINTS = 1000
+      |
+      |  def display[C](originalData:C, fields:Option[(String, String)]=None, maxPoints:Int=0) = {}
+      |  def pairs[C](originalData:C, maxPoints:Int=0) = {}
+      |  def ul(capacity:Int=10, initData:Seq[String]=Nil, prefill:Option[String]=None) = {}
+      |  def ol(capacity:Int=10, initData:Seq[String]=Nil, prefill:Option[String]=None) = {}
+      |  def img(tpe:String="png", width:String="", height:String="") = {}
+      |  def text(value: String) = {}
+      |}
+      |
+      |case class CustomC3Chart[C](
+      |                             originalData: C,
+      |                             chartOptions: String = "{}",
+      |                             sizes: (Int, Int) = (600, 400),
+      |                             maxPoints: Int = DEFAULT_MAX_POINTS
+      |                           )
+      |
+      |case class ScatterChart[C](
+      |                            originalData: C,
+      |                            fields: Option[(String, String)] = None,
+      |                            sizes: (Int, Int) = (600, 400),
+      |                            maxPoints: Int = DEFAULT_MAX_POINTS,
+      |                            groupField: Option[String] = None
+      |                          )
+      |
+      |case class LineChart[C](
+      |                         originalData: C,
+      |                         fields: Option[(String, String)] = None,
+      |                         sizes: (Int, Int) = (600, 400),
+      |                         maxPoints: Int = DEFAULT_MAX_POINTS,
+      |                         groupField: Option[String] = None
+      |                       )
+      |
+      |case class RadarChart[C](
+      |                          originalData: C,
+      |                          labelField: Option[String] = None,
+      |                          sizes: (Int, Int) = (600, 400),
+      |                          maxPoints: Int = DEFAULT_MAX_POINTS
+      |                        )
+      |
+      |
+      |case class ParallelCoordChart[C](
+      |                                  originalData: C,
+      |                                  sizes: (Int, Int) = (600, 400),
+      |                                  maxPoints: Int = DEFAULT_MAX_POINTS
+      |                                )
+      |
+      |case class TimeseriesChart[C](
+      |                               originalData: C,
+      |                               fields: Option[(String, String)] = None,
+      |                               sizes: (Int, Int) = (600, 400),
+      |                               maxPoints: Int = DEFAULT_MAX_POINTS,
+      |                               groupField: Option[String] = None,
+      |                               tickFormat: String = "%Y-%m-%d %H:%M:%S"
+      |                             )
+      |
+      |case class BarChart[C](
+      |                        originalData: C,
+      |                        fields: Option[(String, String)] = None,
+      |                        sizes: (Int, Int) = (600, 400),
+      |                        maxPoints: Int = DEFAULT_MAX_POINTS,
+      |                        groupField: Option[String] = None
+      |                      )
+      |
+      |
+      |case class PieChart[C](
+      |                        originalData: C,
+      |                        fields: Option[(String, String)] = None,
+      |                        sizes: (Int, Int) = (600, 400),
+      |                        maxPoints: Int = DEFAULT_MAX_POINTS
+      |                      )
+      |
+      |case class DiyChart[C](
+      |                        originalData: C,
+      |                        js: String = "",
+      |                        sizes: (Int, Int) = (600, 400),
+      |                        maxPoints: Int = DEFAULT_MAX_POINTS
+      |                      )
+      |
+      |
+      |case class GeoPointsChart[C](
+      |                              originalData: C,
+      |                              sizes: (Int, Int) = (600, 400),
+      |                              maxPoints: Int = DEFAULT_MAX_POINTS,
+      |                              latLonFields: Option[(String, String)] = None,
+      |                              rField: Option[String] = None,
+      |                              colorField: Option[String] = None
+      |                            )
+      |
+      |
+      |case class GeoChart[C](
+      |                        originalData: C,
+      |                        sizes: (Int, Int) = (600, 400),
+      |                        maxPoints: Int = DEFAULT_MAX_POINTS,
+      |                        geometryField: Option[String] = None,
+      |                        rField: Option[String] = None,
+      |                        colorField: Option[String] = None,
+      |                        fillColorField: Option[String] = None
+      |                      )
+      |
+      |case class GraphChart[C](
+      |                          originalData: C,
+      |                          sizes: (Int, Int) = (600, 400),
+      |                          maxPoints: Int = DEFAULT_MAX_POINTS,
+      |                          charge: Int = -30,
+      |                          linkDistance: Int = 20,
+      |                          linkStrength: Double = 1.0
+      |                        )
+      |
+      |
+      |case class PivotChart[C](
+      |                          originalData: C,
+      |                          sizes: (Int, Int) = (600, 400),
+      |                          maxPoints: Int = DEFAULT_MAX_POINTS,
+      |                          // FIXME: otherwise this would add dependency on play-json!
+      |                          // derivedAttributes:JsObject=play.api.libs.json.Json.obj(),
+      |                          options: Map[String, String] = Map.empty
+      |                        )
+      |
+      |
+      |case class CustomPlotlyChart[C](
+      |                                 originalData: C,
+      |                                 layout: String = "{}",
+      |                                 dataOptions: String = "{}",
+      |                                 dataSources: String = "{}",
+      |                                 sizes: (Int, Int) = (600, 400),
+      |                                 maxPoints: Int = DEFAULT_MAX_POINTS
+      |                               )
+      |
+      |case class TableChart[C](
+      |                          originalData: C,
+      |                          filterCol: Option[Seq[String]] = None,
+      |                          sizes: (Int, Int) = (600, 400),
+      |                          maxPoints: Int = DEFAULT_MAX_POINTS
+      |                        )
+      |
+    """.stripMargin
+  }
+}
+
+object Job {
+  val NotebookVarsPrefix = "notebook.custom.vars"
+  object Build {
+    val properties = s"""
+      |
+      |sbt.version=${Sbt.version}
+      |
+      |""".stripMargin.trim
+
+    object Sbt {
+      val version = "0.13.9"
+      val plugins =  s"""
+        |addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.5")
+        |
+        |addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.6")
+        |
+        |addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
+        |""".stripMargin.trim
+    }
+  }
+}

--- a/modules/sbt-project-generator/src/main/scala/com/datafellas/g3nerator/Library.scala
+++ b/modules/sbt-project-generator/src/main/scala/com/datafellas/g3nerator/Library.scala
@@ -1,0 +1,15 @@
+package com.datafellas.g3nerator
+
+import com.datafellas.g3nerator.model.{DebianName, LibraryName, PackageName}
+
+
+case class Library(notebookName:String, groupPackage:String, version: String, majorScalaVersion:String) {
+  val name = LibraryName(notebookName).name
+  val group = groupPackage // project.config.pkg
+  val artifact = name + "_" + majorScalaVersion
+  val classPkg = groupPackage+ "." + PackageName(notebookName).name
+  val jarInDeb = s"$group.$name-$version.jar"
+  val debianPackage = s"${DebianName(notebookName).name}_${version}_all.deb"
+
+  def jarInTargetPath = s"target/scala-$majorScalaVersion/$group.${name}_$majorScalaVersion-$version.jar"
+}

--- a/modules/sbt-project-generator/src/main/scala/com/datafellas/g3nerator/ProjectManager.scala
+++ b/modules/sbt-project-generator/src/main/scala/com/datafellas/g3nerator/ProjectManager.scala
@@ -1,0 +1,162 @@
+package com.datafellas.g3nerator
+
+import java.io.File
+import java.net.URL
+
+import scala.io.Source
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import com.datafellas.g3nerator.model._
+import notebook.io.GitProvider
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class ProjectManager(val projectDir: File, projectStore: ProjectConfigStore, gitProvider: GitProvider) {
+
+  private val gitignore: File = {
+    val f = new File(projectDir, ".gitignore")
+    if (!f.exists) f.createNewFile
+
+    val contents = List(
+      "**/target",
+      "*/jdk",
+      "*/jdk-*",
+      "*/sbt",
+      "out"
+    )
+
+    val igs = scala.io.Source.fromFile(f).getLines.toList
+    val toAdd = contents.filter { l => !igs.exists(_ == l) }
+    val w = new java.io.FileWriter(f, true)
+    toAdd.foreach(s => w.append(s+"\n"))
+    w.close
+    f
+  }
+
+  def publish(project: Project, isPublishLocal:Boolean): Future[Unit] = {
+    gitProvider.refreshLocal()
+    val job = project.mkJob
+
+    for {
+      // we first add to the store, we should update it when terminated
+      // this is important to track the progress (otherwise it won't be available there until the whole gen is done)
+      _ <- Future(projectStore.add(project.config))
+      _ <- job.publish(isPublishLocal)
+      // P.S. if remote git is not configured this only publishes to a local git instance
+      _ <- gitProvider.add(project.config.outputDirectory.get, "Added generated project " + project.name)
+      _ <- gitProvider.push()
+    } yield ()
+  }
+}
+
+trait ProjectConfigStore {
+  def replaceAll(projectConfigs: List[ProjectConfig]) : Unit
+  def add(projectConfig: ProjectConfig): Unit
+  def remove(project: Project): Unit = ???
+  def list: List[ProjectConfig]
+}
+
+class FileProjectStore(projectDir: File) extends ProjectConfigStore {
+
+  val logger = LoggerFactory.getLogger(classOf[FileProjectStore])
+
+  private val store: File = try {
+    new File(projectDir, FileProjectStore.StoreFile)
+  } catch {
+    case t: Throwable => logger.error("Unable to create Project Store File", t)
+      throw new RuntimeException("Unable to create Project Store File", t)
+  }
+
+  try {
+    if (!store.exists) {
+      store.getParentFile.mkdirs()
+      store.createNewFile
+      replaceAll(Nil)
+    }
+  } catch {
+    case t: Throwable => logger.error("Unable to initialize project store", t)
+      throw new RuntimeException("Unable to initialize project store", t)
+  }
+
+  def list: List[ProjectConfig] = {
+    val c = Source.fromFile(store).getLines.mkString("\n")
+    val json = Json.parse(c)
+    ProjectConfigJsonSupport.fromJson(json)
+  }
+
+  def replaceAll(projects: List[ProjectConfig]) : Unit = {
+    val json = ProjectConfigJsonSupport.toJson(projects)
+    FileUtils.writeTo(store)(Json.stringify(json))
+  }
+
+  def add(p: ProjectConfig) = {
+    val allProjects = p :: list.filter(other => other.name != p.name )
+    replaceAll(allProjects)
+  }
+
+}
+object FileProjectStore {
+  val StoreFile = "generated_projects.json"
+}
+
+object ProjectConfigJsonSupport {
+
+  implicit val readUrl:Reads[URL] = new Reads[URL] {
+    override def reads(json: JsValue): JsResult[URL] = {
+      JsSuccess(new URL(json.as[String]))
+    }
+  }
+  implicit val writeUrl:Writes[URL] = new Writes[URL] {
+    def writes(url:URL) = Json.toJson(url.toString)
+  }
+
+  implicit val readCredentials:Reads[Credentials] = (
+    (JsPath \ Credentials.Username).read[String] and
+      (JsPath \ Credentials.Password).read[String])(Credentials.apply _)
+
+  implicit val writeCredentials: Writes[Credentials] = (
+    (JsPath \ Credentials.Username).write[String] and
+      (JsPath \ Credentials.Password).write[String])(unlift(Credentials.unapply))
+
+  implicit val readSecuredUrl:Reads[SecuredUrl] = (
+    (JsPath \ SecuredUrl.Url).read[URL] and
+      (JsPath \ SecuredUrl.Authentication).read[Option[Credentials]]
+    )(SecuredUrl.apply _)
+
+  implicit val writeSecuredUrl:Writes[SecuredUrl] = (
+    (JsPath \ SecuredUrl.Url).write[URL] and
+      (JsPath \ SecuredUrl.Authentication).write[Option[Credentials]]
+    )(unlift(SecuredUrl.unapply))
+
+
+  implicit val projectRead: Reads[ProjectConfig] = (
+    (JsPath \ "pkg").read[String] and
+      (JsPath \ "version").read[String] and
+      (JsPath \ "maintainer").read[String] and
+      (JsPath \ "dockerRepo").read[String] and
+      (JsPath \ "dockercfg").read[String] and
+      (JsPath \ "mesosVersion").read[String] and
+      (JsPath \ "name").readNullable[String] and
+      (JsPath \ "outputDirectory").readNullable[String]
+    )(ProjectConfig.apply _)
+
+  implicit val projectWrite: Writes[ProjectConfig] = (
+    (JsPath \ "pkg").write[String] and
+      (JsPath \ "version").write[String] and
+      (JsPath \ "maintainer").write[String] and
+      (JsPath \ "dockerRepo").write[String] and
+      (JsPath \ "dockercfg").write[String] and
+      (JsPath \ "mesosVersion").write[String] and
+      (JsPath \ "name").writeNullable[String] and
+      (JsPath \ "outputDirectory").writeNullable[String]
+    )(unlift(ProjectConfig.unapply))
+
+  def toJson(config: ProjectConfig): JsValue = Json.toJson(config)
+  def toJson(projects: List[ProjectConfig]): JsValue = Json.toJson(projects)
+  def fromJson(js:JsValue): List[ProjectConfig] = Json.fromJson[List[ProjectConfig]](js) match {
+    case jsConfig: JsSuccess[List[ProjectConfig]] =>  jsConfig.get
+    case err: JsError => throw new RuntimeException("Unable to parse Project Configuration:" + err.toString)
+  }
+}

--- a/modules/sbt-project-generator/src/main/scala/com/datafellas/g3nerator/ZipArchiveUtil.scala
+++ b/modules/sbt-project-generator/src/main/scala/com/datafellas/g3nerator/ZipArchiveUtil.scala
@@ -1,0 +1,127 @@
+package com.datafellas.g3nerator
+
+import java.io.{File, FileInputStream, FileOutputStream, IOException}
+import java.util.zip.{ZipEntry, ZipFile, ZipOutputStream}
+
+import scala.collection.JavaConversions.enumerationAsScalaIterator
+import scala.io.{BufferedSource, Codec}
+
+
+// this support zipping dirs too
+// based on
+// https://github.com/dhbikoff/Scala-Zip-Archive-Util/blob/dfdb96eff2230ea8e8825f1baa161a3d00e60e13/ZipArchiveUtil.scala
+// FIXME: check is this can be more useful https://github.com/pathikrit/better-files#zip-apis
+object ZipArchiveUtil {
+  def createArchiveRecursively(rootPath: String,
+                               inputFiles: Seq[String],
+                               outputFilename: String): Unit = {
+    println(
+      s"rootPath: $rootPath\n" +
+        s"inputFiles: $inputFiles\n" +
+        s"outputFilename: $outputFilename"
+    )
+    val filePaths = inputFiles.map { inputFilePath =>
+      createFileList(new File(inputFilePath).getAbsoluteFile, outputFilename)
+    }.reduce(_ ++ _)
+
+    createZip(filePaths, outputFilename, rootPath)
+  }
+
+  def createFileList(file: File, outputFilename: String): List[String] = {
+    file match {
+      case file if file.isFile => {
+        if (file.getName != outputFilename)
+          List(file.getAbsoluteFile.toString)
+        else
+          List()
+      }
+      case file if file.isDirectory => {
+        val fList = file.list
+        // Add all files in current dir to list and recur on subdirs
+        fList.foldLeft(List[String]())((pList: List[String], path: String) =>
+          pList ++ createFileList(new File(file, path), outputFilename))
+      }
+      case _ => throw new IOException("Bad path. No file or directory found.")
+    }
+  }
+
+  def addFileToZipEntry(filename: String, parentPath: String,
+                        filePathsCount: Int): ZipEntry = {
+    if (filePathsCount <= 1)
+      new ZipEntry(new File(filename).getName)
+    else {
+      // use relative path to avoid adding absolute path directories
+      val relative = new File(parentPath).toURI.
+        relativize(new File(filename).toURI).getPath
+      new ZipEntry(relative)
+    }
+  }
+
+  def createZip(filePaths: List[String], outputFilename: String,
+                parentPath: String) = {
+    try {
+      val fileOutputStream = new FileOutputStream(parentPath + "/"+ outputFilename)
+      val zipOutputStream = new ZipOutputStream(fileOutputStream)
+
+      filePaths.foreach((name: String) => {
+        println("adding " + name)
+        val zipEntry = addFileToZipEntry(name, parentPath, filePaths.size)
+        zipOutputStream.putNextEntry(zipEntry)
+        val inputSrc = new BufferedSource(
+          new FileInputStream(name))(Codec.ISO8859)
+        inputSrc foreach { c: Char => zipOutputStream.write(c) }
+        inputSrc.close
+      })
+
+      zipOutputStream.closeEntry
+      zipOutputStream.close
+      fileOutputStream.close
+
+    } catch {
+      case e: IOException => {
+        e.printStackTrace
+      }
+    }
+  }
+
+  def unzip(file: File): Unit = {
+    val basename = file.getName.substring(0, file.getName.lastIndexOf("."))
+    val destDir = new File(file.getParentFile, basename)
+    destDir.mkdirs
+
+    val zip = new ZipFile(file)
+    zip.entries foreach { entry =>
+      val entryName = entry.getName
+      val entryPath = {
+        if (entryName.startsWith(basename))
+          entryName.substring(basename.length)
+        else
+          entryName
+      }
+
+      // create output directory if it doesn't exist already
+      val splitPath = entry.getName.split(File.separator).dropRight(1)
+      if (splitPath.size >= 1) {
+        // create intermediate directories if they don't exist
+        val dirBuilder = new StringBuilder(destDir.getName)
+        splitPath.foldLeft(dirBuilder)((a: StringBuilder, b: String) => {
+          val path = a.append(File.separator + b)
+          val str = path.mkString
+          if (!(new File(str).exists)) {
+            new File(str).mkdir
+          }
+          path
+        })
+      }
+
+      // write file to dest
+      println("Extracting " + destDir + File.separator + entryPath)
+      val inputSrc = new BufferedSource(
+        zip.getInputStream(entry))(Codec.ISO8859)
+      val ostream = new FileOutputStream(new File(destDir, entryPath))
+      inputSrc foreach { c: Char => ostream.write(c) }
+      inputSrc.close
+      ostream.close
+    }
+  }
+}

--- a/modules/sbt-project-generator/src/main/scala/com/datafellas/g3nerator/model/Artifact.scala
+++ b/modules/sbt-project-generator/src/main/scala/com/datafellas/g3nerator/model/Artifact.scala
@@ -1,0 +1,54 @@
+package com.datafellas.g3nerator.model
+
+import java.io.{File, FileWriter, PrintWriter}
+
+import com.typesafe.config.Config
+
+import scala.util.{Failure, Try}
+
+trait Materializer {
+  def materialize(file: File, content:String) : Try[Unit]
+}
+
+class FileSystemMaterializer() extends Materializer {
+  override def materialize(file: File, content:String) = {
+    if (file.isDirectory) {
+      Failure(new RuntimeException("Artifact target cannot be a directory: " + file.getAbsolutePath))
+    } else {
+      Try {
+        val writer = new PrintWriter(new FileWriter(file))
+        writer.print(content)
+        writer.close
+      }
+    }
+  }
+}
+
+class Artifact[S <: Artifact.State] (val fd: File, val content: String) {
+
+  import Artifact.State._
+
+  def materialize(m: Materializer)(implicit ev: S =:= Unmaterialized): Try[Artifact[Materialized]] = {
+    m.materialize(fd, content).map(_ => new Artifact[Materialized](fd, content))
+  }
+
+  override def equals(other: Any): Boolean = {
+    other match {
+      case o:Artifact[_] => (this.fd == o.fd) && (this.content == o.content)
+      case _ => false
+    }
+  }
+
+  override def hashCode: Int = {
+    17 * fd.hashCode + 31 * content.hashCode
+  }
+}
+
+object Artifact {
+  sealed trait State
+  object State {
+    sealed trait Unmaterialized extends State
+    sealed trait Materialized extends State
+  }
+  def apply(fd:File, content:String) : Artifact[State.Unmaterialized] = new Artifact[State.Unmaterialized](fd, content)
+}

--- a/modules/sbt-project-generator/src/main/scala/com/datafellas/g3nerator/model/ArtifactName.scala
+++ b/modules/sbt-project-generator/src/main/scala/com/datafellas/g3nerator/model/ArtifactName.scala
@@ -1,0 +1,31 @@
+package com.datafellas.g3nerator.model
+
+
+trait ArtifactName {
+  def name: String
+}
+
+object ArtifactName {
+  val NonAlphanumericToDashesTrimmed: String => String = {
+    _.toLowerCase.replaceAll("[^\\.a-z0-9-]+", "-").dropWhile(c => !c.isLetter).reverse.dropWhile(c => !c.isLetter).reverse
+  }
+  val AlphanumericCamelCase: String => String = _.toLowerCase.split("[\\W_]+").map(_.capitalize).mkString("")
+  val AlphanumericLowerCase: String => String = _.toLowerCase.replaceAll("[\\W_]+", "")
+
+}
+
+case class DebianName(source: String) extends ArtifactName {
+  val name: String = ArtifactName.NonAlphanumericToDashesTrimmed(source)
+}
+
+case class ClassName(source: String) extends ArtifactName {
+  val name: String = ArtifactName.AlphanumericCamelCase(source)
+}
+
+case class PackageName(source: String) extends ArtifactName {
+  def name: String = ArtifactName.AlphanumericLowerCase(source)
+}
+
+case class LibraryName(source: String) extends ArtifactName {
+  def name: String  = ArtifactName.NonAlphanumericToDashesTrimmed(source)
+}

--- a/modules/sbt-project-generator/src/main/scala/com/datafellas/g3nerator/model/ConfigParser.scala
+++ b/modules/sbt-project-generator/src/main/scala/com/datafellas/g3nerator/model/ConfigParser.scala
@@ -1,0 +1,19 @@
+package com.datafellas.g3nerator.model
+
+import com.typesafe.config.Config
+
+import scala.util.Try
+
+/**
+  * Some machinery to enable class to provide their parse logic in a consistent way
+  */
+trait ConfigParser[T] {
+  def parseConfig(config:Config):Try[T]
+}
+
+object ConfigParser {
+  def parse[T:ConfigParser](config:Config): Try[T] = {
+    val parser = implicitly[ConfigParser[T]]
+    parser.parseConfig(config)
+  }
+}

--- a/modules/sbt-project-generator/src/main/scala/com/datafellas/g3nerator/model/Credentials.scala
+++ b/modules/sbt-project-generator/src/main/scala/com/datafellas/g3nerator/model/Credentials.scala
@@ -1,0 +1,39 @@
+package com.datafellas.g3nerator.model
+
+import com.typesafe.config.Config
+import notebook.io.ConfigUtils._
+
+import scala.util.Try
+
+/**
+  * Credentials for basic authentication
+  *
+  * @param username
+  * @param password
+  */
+case class Credentials(username: String, password: String)
+object Credentials {
+  val Username = "username"
+  val Password = "password"
+
+  implicit object credentialRender extends Renderable[Credentials] {
+    def render(obj: Credentials, prefix: String) = {
+      val entries = List(
+        StringConfig(Credentials.Username, obj.username),
+        StringConfig(Credentials.Password, obj.password)
+      )
+      Renderable.render(entries, prefix)
+    }
+  }
+
+  implicit object credentialsParser extends ConfigParser[Credentials] {
+    def parseConfig(config: Config): Try[Credentials] = {
+      for {
+        u <- config.tryGetString(Username)
+        p <- config.tryGetString(Password)
+      } yield (Credentials(u, p))
+    }
+  }
+
+}
+

--- a/modules/sbt-project-generator/src/main/scala/com/datafellas/g3nerator/model/DependencyConfig.scala
+++ b/modules/sbt-project-generator/src/main/scala/com/datafellas/g3nerator/model/DependencyConfig.scala
@@ -1,0 +1,17 @@
+package com.datafellas.g3nerator.model
+
+import java.nio.file.Path
+
+//TODO Use type for artifactory, now: (pull, push) → (user, password)
+case class DependencyConfig(resolverCloudera: String,
+                            resolverBintrayDataFellasMvn: String,
+                            resolverBintraySparkPackagesMvn: String,
+                            jdkHome: Path,
+                            sbtHome: Path,
+                            dockerBaseImage: String,
+                            resolverSbtPlugin: String,
+                            artifactory: Option[((String, String), Option[(String, String)])] = None
+                    )
+
+
+

--- a/modules/sbt-project-generator/src/main/scala/com/datafellas/g3nerator/model/Project.scala
+++ b/modules/sbt-project-generator/src/main/scala/com/datafellas/g3nerator/model/Project.scala
@@ -1,0 +1,55 @@
+package com.datafellas.g3nerator.model
+
+import java.io.File
+import java.net.{URL => JURL}
+import java.nio.file.{Files, Path, Paths}
+
+import com.datafellas.g3nerator.Job
+import com.typesafe.config.Config
+import notebook.Notebook
+
+import scala.util.Try
+
+class Project(
+               val snb: Notebook,
+               projectDir: File,
+               initialConfig: ProjectConfig,
+               val dependencyConfig: DependencyConfig,
+               val productionConfig: Option[ProductionConfig] = None
+             ) {
+
+  val RepoPrefix = "repo_gen"
+  val repo = Files.createTempDirectory(s"${RepoPrefix}_${config.pkg}_${config.version}").toFile
+  val name = snb.normalizedName
+  val targetDir = new File (projectDir, name)
+  def config = initialConfig.copy(outputDirectory = Some(name), name = Some(name))
+
+  def mkJob: Job = new Job(this, repo, targetDir)
+
+}
+
+case class ProductionConfig(sparkVersion: String, hadoopVersion:String)
+
+case class ProjectConfig(
+                          pkg:String,
+                          version:String,
+                          maintainer:String,
+                          dockerRepo:String,
+                          dockercfg:String,
+                          mesosVersion:String,
+                          name: Option[String] = None,
+                          outputDirectory: Option[String] = None
+                        ) {
+
+  def toMap: Map[String, String] = {
+    val fixedConfig = Map("pkg" -> pkg,
+      "version" -> version,
+      "maintainer" -> maintainer,
+      "dockerRepo" -> dockerRepo,
+      "dockercfg" -> dockercfg,
+      "mesosVersion" -> mesosVersion
+    )
+    val optionalConfig = List(name.map("name" -> _), outputDirectory.map("outputDirectory" -> _)).flatten
+    fixedConfig ++ optionalConfig
+  }
+}

--- a/modules/sbt-project-generator/src/main/scala/com/datafellas/g3nerator/model/Renderable.scala
+++ b/modules/sbt-project-generator/src/main/scala/com/datafellas/g3nerator/model/Renderable.scala
@@ -1,0 +1,30 @@
+package com.datafellas.g3nerator.model
+
+/**
+  * Renders objects to configuration
+  */
+
+trait Renderable[T] {
+  def render(obj:T, prefix: String): String
+}
+
+object Renderable {
+  def render[T:Renderable](obj:T, prefix: String): String = {
+    val r = implicitly[Renderable[T]]
+    r.render(obj, prefix)
+  }
+
+  def render[T:Renderable](list:List[T], prefix: String): String = {
+    val r = implicitly[Renderable[T]]
+    list.map(elem => r.render(elem, prefix)).mkString("\n")
+  }
+
+  implicit object stringConfigRender extends Renderable[StringConfig] {
+    def render(obj: StringConfig, prefix:String) =
+      s"""|
+          |$prefix.${obj.key}= "${obj.value}"
+          |""".stripMargin
+  }
+}
+
+case class StringConfig(key:String, value:String)

--- a/modules/sbt-project-generator/src/main/scala/com/datafellas/g3nerator/model/SecuredUrl.scala
+++ b/modules/sbt-project-generator/src/main/scala/com/datafellas/g3nerator/model/SecuredUrl.scala
@@ -1,0 +1,48 @@
+package com.datafellas.g3nerator.model
+
+import java.net.{URL => JURL}
+
+import com.typesafe.config.Config
+
+import scala.util.{Failure, Success, Try}
+import notebook.io.ConfigUtils._
+import notebook.io.ConfigurationMissingException
+
+/**
+  * An endpoint that requires credentials
+  */
+case class SecuredUrl(url: JURL, credentials: Option[Credentials]){
+  def toCurlCredentials:String = credentials.map(cred => s"-u '${cred.username}:${cred.password}'").getOrElse("")
+}
+
+object SecuredUrl {
+
+  val Url = "url"
+  val Authentication = "authentication"
+
+  implicit object securedUrlRender extends Renderable[SecuredUrl] {
+    def render(obj: SecuredUrl, prefix: String) = {
+      obj.credentials.foldLeft(Renderable.render(StringConfig(Url, obj.url.toString), prefix))((url, cred) =>
+        url + "\n" + Renderable.render(cred, prefix + "." + Authentication))
+    }
+  }
+
+  implicit object securedUrlParser extends ConfigParser[SecuredUrl] {
+    def parseConfig(config: Config): Try[SecuredUrl] = {
+      for {
+        strUrl <- config.tryGetString(Url)
+        url <- Try {
+          URL(strUrl)
+        }
+        credConfig <- config.tryGetPath(Authentication).map(Some(_))
+          .recoverWith { case ex: ConfigurationMissingException => Success(None) }
+        credentials <- credConfig.map(config => ConfigParser.parse[Credentials](config)) match {
+          case Some(Success(cred)) => Success(Some(cred))
+          case Some(Failure(ex)) => Failure(ex)
+          case None => Success(None)
+        }
+      } yield SecuredUrl(url, credentials)
+    }
+  }
+
+}

--- a/modules/sbt-project-generator/src/main/scala/com/datafellas/g3nerator/model/UrlUtils.scala
+++ b/modules/sbt-project-generator/src/main/scala/com/datafellas/g3nerator/model/UrlUtils.scala
@@ -1,0 +1,18 @@
+package com.datafellas.g3nerator.model
+
+import java.net.{URL => JURL}
+
+object URL {
+
+  def apply(url: String): JURL = new JURL(url)
+
+  implicit class URLOps(val url: JURL) extends AnyVal {
+    def / (path: String): JURL = {
+      val trailingBaseSlash = if (url.getPath.lastOption != Some('/')) new JURL(url, url.getPath + "/") else url
+      val noLeadingSlash = if (path.headOption == Some('/')) path.drop(1) else path
+      new JURL(trailingBaseSlash , noLeadingSlash)
+    }
+  }
+
+}
+

--- a/modules/sbt-project-generator/src/test/resources/snb/generator-simple.snb
+++ b/modules/sbt-project-generator/src/test/resources/snb/generator-simple.snb
@@ -1,0 +1,107 @@
+{
+  "cells": [
+    {
+      "metadata": {
+        "trusted": true,
+        "input_collapsed": false,
+        "collapsed": false,
+        "id": "99EA30C352824AEA8E0FFB0BB80DF3C0"
+      },
+      "cell_type": "code",
+      "source": "val sqlContext = new org.apache.spark.sql.SQLContext(sparkContext)\nimport sqlContext.implicits._",
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": "sqlContext: org.apache.spark.sql.SQLContext = org.apache.spark.sql.SQLContext@5d27a147\nimport sqlContext.implicits._\n",
+          "name": "stdout"
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/html": ""
+          },
+          "metadata": {},
+          "execution_count": 1,
+          "time": "Took: 1 second 544 milliseconds, at 2016-7-1 14:42"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "trusted": true,
+        "input_collapsed": false,
+        "collapsed": false,
+        "id": "6765C9EA0D9E4F2B9D932A158DF29518"
+      },
+      "cell_type": "code",
+      "source": "val df = (1 to 1000).map { i =>\n  (i, i.toLong, i.toDouble, i.toFloat, i % 2 == 0, \"\"+i)\n}.toDF(\"f_int\", \"f_long\", \"f_double\", \"f_float\", \"f_boolean\", \"f_string\")",
+      "execution_count": 2,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": "df: org.apache.spark.sql.DataFrame = [f_int: int, f_long: bigint, f_double: double, f_float: float, f_boolean: boolean, f_string: string]\n",
+          "name": "stdout"
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/html": ""
+          },
+          "metadata": {},
+          "execution_count": 2,
+          "time": "Took: 1 second 551 milliseconds, at 2016-7-1 14:42"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "id": "881104B050734087A97D90BBE3E7DC77",
+        "trusted": true,
+        "collapsed": true,
+        "input_collapsed": false
+      },
+      "cell_type": "code",
+      "source": "df.rdd.foreach(println)",
+      "execution_count": null,
+      "outputs": []
+    }
+  ],
+  "metadata": {
+    "name": "generator-simple",
+    "user_save_timestamp": "1969-12-31T16:00:00.000Z",
+    "auto_save_timestamp": "1969-12-31T16:00:00.000Z",
+    "language_info": {
+      "name": "scala",
+      "file_extension": "scala",
+      "codemirror_mode": "text/x-scala"
+    },
+    "trusted": true,
+    "customLocalRepo": "/home/noootsab/.ivy2",
+    "customRepos": null,
+    "customDeps": [
+      "com.datastax.spark:spark-cassandra-connector_2.10:1.4.0-M3",
+      "- org.apache.spark %% spark-core % _",
+      "- org.apache.spark %% spark-streaming % _",
+      "- org.apache.hadoop % _ % _",
+      "- org.scala-lang % _ % _"
+    ],
+    "customImports": null,
+    "customArgs": null,
+    "customSparkConf": {
+      "spark.cassandra.connection.host": "172.17.0.1",
+      "spark.scheduler.mode": "FAIR"
+    },
+    "customVars": {
+        "HDFS_ROOT": "/tmp",
+        "NOTEBOOK_USER": "${USER}"
+     },
+    "kernelspec": {
+      "name": "spark",
+      "display_name": "Scala [2.10.5] Spark [1.6.1] Hadoop [2.2.0]  "
+    },
+    "celltoolbar": "Edit Metadata"
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/modules/sbt-project-generator/src/test/scala/com/datafellas/g3nerator/DataSamples.scala
+++ b/modules/sbt-project-generator/src/test/scala/com/datafellas/g3nerator/DataSamples.scala
@@ -1,0 +1,27 @@
+package com.datafellas.g3nerator
+
+import java.nio.file.Paths
+
+import com.datafellas.g3nerator.model.DependencyConfig
+
+import scala.io.Source
+
+object DataSamples {
+
+  val CommonUrlConfig = DependencyConfig(
+    "resolverCloudera",
+    "http://dl.bintray.com/spark-packages/maven/", //resolverBintrayDataFellasMvn",
+    "http://dl.bintray.com/spark-packages/maven/",
+    Paths.get("/opt/java/jdk"),
+    Paths.get("/opt/sbt/"),
+    "dockerBaseImage",
+    "https://bintray.com/sbt/sbt-plugin-releases"
+  )
+
+  def loadNotebook(name:String): String = {
+    val sampleNotebookDir = "/snb/"
+    Source.fromURL(getClass.getResource(sampleNotebookDir + name)).getLines().mkString("\n")
+  }
+
+
+}

--- a/modules/sbt-project-generator/src/test/scala/com/datafellas/g3nerator/FileProjectStoreTests.scala
+++ b/modules/sbt-project-generator/src/test/scala/com/datafellas/g3nerator/FileProjectStoreTests.scala
@@ -1,0 +1,88 @@
+package com.datafellas.g3nerator
+
+import java.io.File
+import java.nio.file.{Files, Paths}
+
+import com.datafellas.g3nerator.FileUtils._
+import com.datafellas.g3nerator.model._
+import notebook.Notebook
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+
+class FileProjectStoreTests extends WordSpec with Matchers with BeforeAndAfterAll {
+
+  var tempDir: File = _
+  var project: Project = _
+
+  val snb = Await.result(Notebook.deserializeFuture(DataSamples.loadNotebook("generator-simple.snb")), 10 seconds)
+
+  override def beforeAll(): Unit = {
+    tempDir = Files.createTempDirectory("project-store-test").toFile
+
+    val projectConfig = ProjectConfig(pkg = "pkg",
+      version = "0.0.1",
+      maintainer = "tester-maintainer",
+      dockerRepo = "dockerRepo",
+      dockercfg = "dockercfg",
+      mesosVersion = "mesosVersion"
+    )
+
+    project =  new Project(snb = snb,
+      projectDir = tempDir,
+      initialConfig = projectConfig,
+      dependencyConfig = DataSamples.CommonUrlConfig,
+      productionConfig = None
+    )
+  }
+
+
+  val sampleProjectConfig =
+    """
+      |[ { "pkg" : "pkg",
+      |    "version" : "0.0.1",
+      |    "maintainer" : "tester-maintainer",
+      |    "dockerRepo" : "dockerRepo",
+      |    "dockercfg" : "dockercfg",
+      |    "mesosVersion" : "mesosVersion",
+      |    "name" : "sample-project",
+      |    "outputDirectory" : "sample-project"}
+      |]
+    """.stripMargin
+
+  "A ProjectStore" should {
+    "create a new empty store given an empty directory" in {
+      val emptyDir = tempDir / "empty"
+      val store = new FileProjectStore(emptyDir)
+      store.list should be ('empty)
+    }
+
+    "create a new store using an existing definition file" in {
+      val existingStoreDir = tempDir / "non-empty"
+      val existingStore = existingStoreDir(FileProjectStore.StoreFile)
+      FileUtils.writeTo(existingStore)(sampleProjectConfig)
+      val store = new FileProjectStore(existingStoreDir)
+      store.list.size should be (1)
+    }
+
+    "store a new project" in {
+      val emptyDir = tempDir / "empty-2"
+      val store = new FileProjectStore(emptyDir)
+      store.add(project.config)
+      store.list.size should be (1)
+      store.list.head.name should be (Some("generator-simple"))
+    }
+
+    "support adding the same project twice" in {
+      val emptyDir = tempDir / "empty-3"
+      val store = new FileProjectStore(emptyDir)
+      store.add(project.config)
+      store.add(project.config)
+      store.list.size should be (1)
+    }
+
+  }
+}

--- a/modules/sbt-project-generator/src/test/scala/com/datafellas/g3nerator/model/ArtifactNameTest.scala
+++ b/modules/sbt-project-generator/src/test/scala/com/datafellas/g3nerator/model/ArtifactNameTest.scala
@@ -1,0 +1,32 @@
+package com.datafellas.g3nerator.model
+
+import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.prop.TableDrivenPropertyChecks._
+
+class ArtifactNameTest extends WordSpec with Matchers {
+
+  val names = Table (
+    ("notebook", "debian", "class", "package", "library"),
+    ("nb", "nb" , "Nb", "nb", "nb"),
+    ("my_notebook", "my-notebook", "MyNotebook", "mynotebook", "my-notebook"),
+    ("dash-notebook", "dash-notebook", "DashNotebook", "dashnotebook", "dash-notebook"),
+    ("great-stuff!!!", "great-stuff", "GreatStuff", "greatstuff", "great-stuff"),
+    ("wow notebook","wow-notebook","WowNotebook","wownotebook", "wow-notebook"),
+    ("mega_wow_notebook","mega-wow-notebook","MegaWowNotebook","megawownotebook", "mega-wow-notebook"),
+    ("shit#!^!!_doesnt_work","shit-doesnt-work","ShitDoesntWork","shitdoesntwork", "shit-doesnt-work"),
+    ("***FINALLY_WORKING***","finally-working","FinallyWorking","finallyworking", "finally-working"),
+    ("","","","", "") // is this a valid name anyway!?
+  )
+
+  "Artifact Name" should {
+    "comply with naming conventions" in {
+      forAll(names) {(notebook: String, debian: String, clazz:String, pkg:String, lib:String) =>
+        DebianName(notebook).name should be (debian)
+        ClassName(notebook).name should be (clazz)
+        PackageName(notebook).name should be (pkg)
+        LibraryName(notebook).name should be (lib)
+      }
+    }
+  }
+
+}

--- a/modules/sbt-project-generator/src/test/scala/com/datafellas/g3nerator/model/ProjectTests.scala
+++ b/modules/sbt-project-generator/src/test/scala/com/datafellas/g3nerator/model/ProjectTests.scala
@@ -1,0 +1,81 @@
+package com.datafellas.g3nerator.model
+
+import java.io.File
+import java.nio.file.{Files, Paths}
+
+import com.datafellas.g3nerator.{DataSamples, Job}
+import com.typesafe.config.ConfigFactory
+import notebook.NBSerializer.CodeCell
+import notebook.Notebook
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import org.scalatest.{BeforeAndAfterAll, Matchers, OptionValues, WordSpec}
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.io.Source
+
+class ProjectTests extends WordSpec with Matchers with BeforeAndAfterAll with OptionValues  {
+
+  var tempDir:File = _
+  var project: Project = _
+
+  override def beforeAll(): Unit = {
+    tempDir =  Files.createTempDirectory("project-test").toFile
+
+    project =  new Project(snb = snb,
+      projectDir = tempDir,
+      initialConfig = projectConfig,
+      dependencyConfig = DataSamples.CommonUrlConfig,
+      productionConfig = None
+    )
+  }
+
+  // notebook name in metadata: generator-output-simple-parquet
+  val notebook = DataSamples.loadNotebook("generator-simple.snb")
+
+  val snb = Await.result(Notebook.deserializeFuture(notebook), 10 seconds)
+
+  val projectConfig = ProjectConfig(pkg = "pkg",
+    version = "0.0.1",
+    maintainer = "tester-maintainer",
+    dockerRepo = "dockerRepo",
+    dockercfg = "dockercfg",
+    mesosVersion = "mesosVersion"
+  )
+
+  "a Project" should {
+
+    "generate a job" in {
+      println("Job temp dir:" + tempDir)
+      val job: Job = project.mkJob
+      job.root.getAbsolutePath should startWith (tempDir.getAbsolutePath)
+
+      job.`root/build.sbt`.getAbsolutePath should startWith (tempDir.getAbsolutePath)
+      job.`root/build.sbt`.getAbsolutePath should endWith ("build.sbt")
+      job.generateOnly(local=true)
+
+      job.`root/src/main/resources/application.conf`.exists() should be (true)
+      // generated configuration should be valid
+      val appConf = Source.fromFile(job.`root/src/main/resources/application.conf`).getLines().mkString("\n")
+      val conf = try {
+        ConfigFactory.parseString(appConf)
+      } catch {
+        case t:Throwable => fail("failed to parse generated configuration:" + t.getMessage, t)
+      }
+      val customVars = conf.getConfig(Job.NotebookVarsPrefix)
+      // these are fragile tests if we change the test data
+      customVars.entrySet().size() should be (2)
+      customVars.getString("HDFS_ROOT") should be ("/tmp")
+    }
+
+  }
+  "A test" should {
+    "print the dir" in {
+      println(" Using test dir:" + tempDir)
+    }
+  }
+
+}
+
+

--- a/modules/sbt-project-generator/src/test/scala/com/datafellas/g3nerator/model/SecuredUrlTests.scala
+++ b/modules/sbt-project-generator/src/test/scala/com/datafellas/g3nerator/model/SecuredUrlTests.scala
@@ -1,0 +1,62 @@
+package com.datafellas.g3nerator.model
+
+import com.typesafe.config.ConfigFactory
+import notebook.io.ConfigurationMissingException
+import org.scalatest.{Matchers, OptionValues, TryValues, WordSpec}
+
+import scala.collection.JavaConverters._
+
+class SecuredUrlTests extends WordSpec with Matchers with TryValues with OptionValues {
+
+  "SecuredUrl" should {
+    val url = "http://some-server:1234"
+    val user = "someUser"
+    val pwd = "somePwd"
+
+    "parse a valid configuration with URL and Credentials" in {
+      val conf = ConfigFactory.parseMap(Map(
+        "url"-> url,
+        "authentication.username" -> user,
+        "authentication.password" -> pwd).asJava
+      )
+      val securedUrl = ConfigParser.parse[SecuredUrl](conf)
+      val res = securedUrl.success.value
+      res.url should be (URL(url))
+      res.credentials.value should be (Credentials(user,pwd))
+    }
+
+    "parse a valid configuration with URL and no Credentials" in {
+      val conf = ConfigFactory.parseMap(
+        Map("url"-> url).asJava
+      )
+      val securedUrl = ConfigParser.parse[SecuredUrl](conf)
+      val res = securedUrl.success.value
+      res.url should be (URL(url))
+      res.credentials should be ('empty)
+    }
+
+    "fail parsing an  invalid configuration without URL and valid credentials" in {
+      val conf = ConfigFactory.parseMap(Map(
+        "badurl"-> url,
+        "authentication.username" -> user,
+        "authentication.password" -> pwd).asJava
+      )
+      val securedUrl = ConfigParser.parse[SecuredUrl](conf)
+      val res = securedUrl.failure
+      res.exception shouldBe a[ConfigurationMissingException]
+      res.exception.asInstanceOf[ConfigurationMissingException].key should be ("url")
+    }
+
+    "fail parsing an  invalid configuration with valid URL and invalid credentials" in {
+      val conf = ConfigFactory.parseMap(Map(
+        "url"-> url,
+        "authentication.foosername" -> user,
+        "authentication.password" -> pwd).asJava
+      )
+      val securedUrl = ConfigParser.parse[SecuredUrl](conf)
+      val res = securedUrl.failure
+      res.exception shouldBe a[ConfigurationMissingException]
+      res.exception.asInstanceOf[ConfigurationMissingException].key should be ("username")
+    }
+  }
+}

--- a/modules/sbt-project-generator/src/test/scala/com/datafellas/g3nerator/model/UrlConfigTests.scala
+++ b/modules/sbt-project-generator/src/test/scala/com/datafellas/g3nerator/model/UrlConfigTests.scala
@@ -1,0 +1,41 @@
+package com.datafellas.g3nerator.model
+
+import java.net.{URL => JURL}
+import java.nio.file.Paths
+
+import org.scalatest.{Matchers, WordSpec}
+
+class URLTests extends WordSpec with Matchers {
+  import com.datafellas.g3nerator.model.URL._
+
+  "an URL (wrapper)" should {
+    "create an URL from a valid url in a String" in {
+      URL("http://host:9876/path") should be (new JURL("http://host:9876/path"))
+    }
+
+    "create a new URL from a base host a relative path" in {
+      val baseURL = URL("http://host:9876")
+      baseURL / "sub/path" should be (new JURL("http://host:9876/sub/path"))
+    }
+
+    "create a new URL from a base URL and a relative path" in {
+      val baseURL = URL("http://host:9876/path")
+      baseURL / "sub/path" should be (new JURL("http://host:9876/path/sub/path"))
+    }
+
+    "chain sub paths to create a new URL " in {
+      val baseURL = URL("http://host:9876/path")
+      baseURL / "sub" / "path" should be (new JURL("http://host:9876/path/sub/path"))
+    }
+
+    "allow trailing slash with chainining sub paths to create a new URL " in {
+      val baseURL = URL("http://host:9876/path")
+      baseURL / "sub/" / "path" should be (new JURL("http://host:9876/path/sub/path"))
+    }
+
+    "allow leading slash with chainining sub paths to create a new URL " in {
+      val baseURL = URL("http://host:9876/path")
+      baseURL / "/sub" / "/path" / "end" should be (new JURL("http://host:9876/path/sub/path/end"))
+    }
+  }
+}

--- a/notebooks/core/Simple Spark.snb
+++ b/notebooks/core/Simple Spark.snb
@@ -1,68 +1,139 @@
 {
   "metadata" : {
+    "id" : "af838c83-8642-46b6-9358-12ee05e704e1",
     "name" : "Simple Spark",
     "user_save_timestamp" : "2014-10-11T17:33:45.703Z",
     "auto_save_timestamp" : "2015-01-10T00:02:12.659Z",
     "language_info" : {
-      "name" : "Scala",
+      "name" : "scala",
       "file_extension" : "scala",
       "codemirror_mode" : "text/x-scala"
     },
     "trusted" : true,
+    "sparkNotebook" : null,
     "customLocalRepo" : null,
     "customRepos" : null,
     "customDeps" : null,
     "customImports" : null,
     "customArgs" : null,
-    "customSparkConf" : null
+    "customSparkConf" : null,
+    "customVars" : null
   },
   "cells" : [ {
-    "metadata" : { },
+    "metadata" : {
+      "id" : "37DEEDC733044DD9972E9E4BA2F1B126"
+    },
     "cell_type" : "markdown",
     "source" : "### Spark config"
   }, {
     "metadata" : {
       "trusted" : true,
-      "collapsed" : false
+      "input_collapsed" : false,
+      "collapsed" : true,
+      "id" : "2A2F6AA618AC48018D01E7D2F4183B76"
     },
     "cell_type" : "code",
     "source" : "sparkContext.getConf.toDebugString",
     "outputs" : [ ]
   }, {
     "metadata" : {
-      "trusted" : true,
-      "collapsed" : false
+      "id" : "DAFA77C3B6D140FF8AAE30B94D2FC73E"
     },
-    "cell_type" : "code",
-    "source" : "val count = sparkContext.makeRDD((1 to 1000).toArray).count()\n()",
-    "outputs" : [ ]
-  }, {
-    "metadata" : { },
     "cell_type" : "markdown",
     "source" : "#### Counting"
   }, {
     "metadata" : {
       "trusted" : true,
-      "collapsed" : false
+      "input_collapsed" : false,
+      "collapsed" : false,
+      "id" : "9088B578DE2F4BA48DF323F11895488A"
     },
     "cell_type" : "code",
-    "source" : "<strong>{count} items</strong>",
+    "source" : "def transform(i: Int) = (i, i+1)",
+    "outputs" : [ {
+      "name" : "stdout",
+      "output_type" : "stream",
+      "text" : "transform: (i: Int)(Int, Int)\n"
+    }, {
+      "metadata" : { },
+      "data" : {
+        "text/html" : ""
+      },
+      "output_type" : "execute_result",
+      "execution_count" : 2,
+      "time" : "Took: 0.727s, at 2017-05-16 12:18"
+    } ]
+  }, {
+    "metadata" : {
+      "trusted" : true,
+      "input_collapsed" : false,
+      "collapsed" : false,
+      "presentation" : {
+        "tabs_state" : "{\n  \"tab_id\": \"#tab662761867-0\"\n}",
+        "pivot_chart_state" : "{\n  \"hiddenAttributes\": [],\n  \"menuLimit\": 200,\n  \"cols\": [],\n  \"rows\": [],\n  \"vals\": [],\n  \"exclusions\": {},\n  \"inclusions\": {},\n  \"unusedAttrsVertical\": 85,\n  \"autoSortUnusedAttrs\": false,\n  \"inclusionsInfo\": {},\n  \"aggregatorName\": \"Count\",\n  \"rendererName\": \"Table\"\n}"
+      },
+      "id" : "BF434E47187740E78B7A7A521D2D87DD"
+    },
+    "cell_type" : "code",
+    "source" : "val dataset = sparkSession.createDataset(1 to 1000).map(transform)",
+    "outputs" : [ {
+      "name" : "stdout",
+      "output_type" : "stream",
+      "text" : "dataset: org.apache.spark.sql.Dataset[(Int, Int)] = [_1: int, _2: int]\n"
+    }, {
+      "metadata" : { },
+      "data" : {
+        "text/html" : ""
+      },
+      "output_type" : "execute_result",
+      "execution_count" : 9,
+      "time" : "Took: 1.466s, at 2017-05-16 12:20"
+    } ]
+  }, {
+    "metadata" : {
+      "trusted" : true,
+      "input_collapsed" : false,
+      "collapsed" : false,
+      "presentation" : {
+        "tabs_state" : "{\n  \"tab_id\": \"#tab1070475139-0\"\n}",
+        "pivot_chart_state" : "{\n  \"hiddenAttributes\": [],\n  \"menuLimit\": 200,\n  \"cols\": [],\n  \"rows\": [],\n  \"vals\": [],\n  \"exclusions\": {},\n  \"inclusions\": {},\n  \"unusedAttrsVertical\": 85,\n  \"autoSortUnusedAttrs\": false,\n  \"inclusionsInfo\": {},\n  \"aggregatorName\": \"Count\",\n  \"rendererName\": \"Table\"\n}"
+      },
+      "id" : "EE80B60DB2C645D58B30EB2B793A5BEC"
+    },
+    "cell_type" : "code",
+    "source" : "display(dataset.toDF)",
     "outputs" : [ ]
   }, {
     "metadata" : {
       "trusted" : true,
-      "collapsed" : false
+      "input_collapsed" : false,
+      "collapsed" : false,
+      "id" : "7797C8DBEB7643D788F4D14F6C8E2B40"
     },
     "cell_type" : "code",
-    "source" : "val i:Int = 2",
-    "outputs" : [ ]
+    "source" : "val sum = dataset.map(_._2).reduce(_+_)\n\nprintln(sum)",
+    "outputs" : [ {
+      "name" : "stdout",
+      "output_type" : "stream",
+      "text" : "501500\nsum: Int = 501500\n"
+    }, {
+      "metadata" : { },
+      "data" : {
+        "text/html" : ""
+      },
+      "output_type" : "execute_result",
+      "execution_count" : 11,
+      "time" : "Took: 1.146s, at 2017-05-16 12:20"
+    } ]
   }, {
     "metadata" : {
       "trusted" : true,
-      "collapsed" : false
+      "input_collapsed" : false,
+      "collapsed" : true,
+      "id" : "73F60C7C9F2945E38AC0C252F2C3AC1E"
     },
     "cell_type" : "code",
-    "source" : "val sum = sparkContext.makeRDD((1 to 1000).toArray).map(_ + i).reduce(_+_)\n",
+    "source" : "",
     "outputs" : [ ]
   } ],
   "nbformat" : 4

--- a/notebooks/viz/Simple & Flexible Custom C3 Charts.snb
+++ b/notebooks/viz/Simple & Flexible Custom C3 Charts.snb
@@ -75,7 +75,7 @@
       "collapsed" : false
     },
     "cell_type" : "code",
-    "source" : "val sqlContext = new org.apache.spark.sql.SQLContext(sparkContext)\nimport sqlContext.implicits._\n\nval salariesDf = Seq(\n  (\"ben\", 3000),\n  (\"boris\", 5000)\n).toDF(\"name\", \"salary_eur\")\n\nCustomC3Chart(salariesDf,\n             chartOptions = \"\"\"\n             { data: { x: 'name', \n                       type: 'bar'},\n               axis: {x: { type: 'categorical' }}\n             }\n             \"\"\")",
+    "source" : "//val sqlContext = new org.apache.spark.sql.SQLContext(sparkContext)\n// import sqlContext.implicits._\n\nval salariesDf = Seq(\n  (\"ben\", 3000),\n  (\"boris\", 5000)\n).toDF(\"name\", \"salary_eur\")\n\nCustomC3Chart(salariesDf,\n             chartOptions = \"\"\"\n             { data: { x: 'name', \n                       type: 'bar'},\n               axis: {x: { type: 'categorical' }}\n             }\n             \"\"\")",
     "outputs" : [ ]
   }, {
     "metadata" : {

--- a/public/ipython/custom/custom.css
+++ b/public/ipython/custom/custom.css
@@ -229,3 +229,6 @@ body[data-read-only="true"] .cell .progress, body[data-read-only="true"] #mainto
 .list_container > div.list_item.row { border: none!important; }
 .list_item.row:nth-child(even) {background: #FAFAFA}
 .list_item.row:nth-child(odd) {background: #FFFFFF}
+
+
+.sbt-project-action { margin-left: 10px; }

--- a/public/ipython/tree/js/main.js
+++ b/public/ipython/tree/js/main.js
@@ -13,6 +13,7 @@ require([
     'tree/js/notebooklist',
     'tree/js/clusterlist',
     'tree/js/dockerlist',
+    '../javascripts/adalog/tree/projectlist',
     'tree/js/sessionlist',
     'tree/js/kernellist',
     'tree/js/terminallist',
@@ -34,6 +35,7 @@ require([
     notebooklist,
     clusterlist,
     dockerlist,
+    projectlist,
     sesssionlist,
     kernellist,
     terminallist,
@@ -86,6 +88,12 @@ require([
         new_notebook: new_buttons},
         common_options));
 
+    // SBT project generation
+    var project_list = new projectlist.ProjectList('#project_list', $.extend({
+        contents: contents},
+        common_options));
+    // end of SBT project generation
+
     var docker_list = new dockerlist.DockerList('#docker_list', $.extend({
             contents: contents,
             new_docker: null//new_buttons
@@ -102,6 +110,7 @@ require([
          *refresh immediately , then start interval
          */
         session_list.load_sessions();
+        project_list.load_list();
         cluster_list.load_list();
         if (terminal_list) {
             terminal_list.load_terminals();
@@ -141,6 +150,7 @@ require([
     IPython.page = page;
     IPython.notebook_list = notebook_list;
     IPython.cluster_list = cluster_list;
+    IPython.project_list = project_list;
     IPython.session_list = session_list;
     IPython.kernel_list = kernel_list;
     IPython.login_widget = login_widget;

--- a/public/ipython/tree/js/notebooklist.js
+++ b/public/ipython/tree/js/notebooklist.js
@@ -43,6 +43,14 @@ define([
         this.sessions = {};
         this.base_url = options.base_url || utils.get_body_data("baseUrl");
         this.notebook_path = options.notebook_path || utils.get_body_data("notebookPath");
+
+        // sbt-project-generation
+        this.sbt_project_gen_enabled = options.sbt_project_gen_enabled || utils.get_body_data("sbt_project_gen_enabled");
+        this.docker_repo = options.docker_repo || utils.get_body_data("dockerRepo");
+        this.maintainer = options.maintainer || utils.get_body_data("maintainer");
+        this.deploy_package_base = options.deploy_package_base || utils.get_body_data("deployPackageBase");
+        this.mesos_version = options.mesos_version || utils.get_body_data("mesosVersion");
+
         this.contents = options.contents;
         if (this.session_list && this.session_list.events) {
             this.session_list.events.on('sessions_loaded.Dashboard',
@@ -324,6 +332,9 @@ define([
             } else {
                 this.add_shutdown_button(item, this.sessions[path]);
             }
+            if (this.sbt_project_gen_enabled === "true") {
+                this.add_generate_button(item);
+            }
         }
     };
 
@@ -385,6 +396,146 @@ define([
         url = this.maybe_read_only_url(url, true)
         var view_button = $("<a target='_blank' href="+url+"/>").html("<span class='text text-warning'>View (read-only)</span>").addClass("btn btn-default btn-xs");
         item.find(item_buttons_selector).prepend(view_button);
+    };
+
+    // toISOString
+    // official toISOString returns the seconds and milliseconds we don't include here
+    function pad(number) {
+      if ( number < 10 ) {
+        return '0' + number;
+      }
+      return number;
+    }
+    function ISODate() {
+      var d = new Date();
+      return d.getUTCFullYear() +
+        '-' + pad( d.getUTCMonth() + 1 ) +
+        '-' + pad( d.getUTCDate() ) +
+        'T' + pad( d.getUTCHours() ) +
+        ':' + pad( d.getUTCMinutes() ) +
+        //':' + pad( d.getUTCSeconds() ) +
+        //'.' + (d.getUTCMilliseconds() / 1000).toFixed(3).slice(2, 5) +
+        'Z';
+    };
+    // \\ toISOString
+
+    NotebookList.prototype.add_generate_button = function (item) {
+        var notebooklist = this;
+        var generate_button = $("<button/>").text("Generate SBT project").addClass("btn btn-default btn-xs btn-success").
+            click(function (e) {
+                // $(this) is the button that was clicked.
+                var that = $(this);
+                var name = item.data('name');
+                var path = item.data('path');
+                var cronDef = ISODate();
+                var destDir = path.replace(".snb", "").replace(/\W+/g, "__")
+                var message = $(
+                    '<div>'+
+                        '<div class="hidden">'+
+                            '<label><strong>In which directory do you want to generate an SBT project?</strong></label>'+
+                            '<br>'+
+                            '<input class="to_dir" type="text" value="' + destDir + '" style="width: 85%" />'+
+                        '</div>'+
+
+                        '<label><strong>What is the package for the classes?</strong></label>'+
+                        '<br>'+
+                        '<input class="pkg" type="text" style="width: 85%" value="'+notebooklist.deploy_package_base+'"/>'+
+
+                        '<label><strong>What is the version of the project?</strong></label>'+
+                        '<br>'+
+                        '<input class="version" type="text" style="width: 85%" value="0.0.1-SNAPSHOT"/>'+
+
+                        '<div class="hidden sbt-gen-optional">'+
+                            '<label><strong>Who is the maintainer of the project?</strong></label>'+
+                            '<br>'+
+                            '<input class="maintainer" type="text" style="width: 85%" value="'+notebooklist.maintainer+'"/>'+
+                        '</div>'+
+
+                        '<div class="hidden sbt-gen-optional">'+
+                            '<label><strong>What is the docker repo for the generated project?</strong></label>'+
+                            '<br>'+
+                            '<input class="docker_repo" type="text" style="width: 85%" value="'+notebooklist.docker_repo+'"/>'+
+                        '</div>'+
+
+                        '<div class="hidden sbt-gen-optional">'+
+                            '<label><strong>What is the mesos version for the generated project?</strong></label>'+
+                            '<br>'+
+                            '<input class="mesos_version" type="text" style="width: 85%" value="'+notebooklist.mesos_version+'"/>'+
+                        '</div>'+
+
+                        '<div>'+
+                            '<a href="#" id="sbt-gen-more-settings-showhide">More settings (show/hide)</a>'+
+                        '</div>'+
+                    '</div>'
+                );
+                message.find("#sbt-gen-more-settings-showhide").click(function (event) {
+                  event.preventDefault();
+                  $(".sbt-gen-optional").toggleClass("hidden");
+                });
+                IPython.dialog.modal({
+                    title : "Generate SBT project for " + name,
+                    body : message,
+                    buttons : {
+                        Generate : {
+                            class: "btn-primary",
+                            click: function() {
+                                var to_dir             = this.find("input.to_dir").val();
+                                var pkg                = this.find("input.pkg").val();
+                                var version            = this.find("input.version").val();
+                                var maintainer         = this.find("input.maintainer").val();
+                                var docker_repo        = this.find("input.docker_repo").val();
+                                var mesos_version      = this.find("input.mesos_version").val();
+                                notebooklist.generate_nb_project(
+                                                            path, pkg, version, maintainer,
+                                                            docker_repo, mesos_version, to_dir
+                                                        ).then(
+                                                            function() {
+                                                                notebooklist.project_generated(name, to_dir);
+                                                            }
+                                                        );
+                            }
+                        },
+                        Cancel : {}
+                    }
+                });
+                return false;
+            });
+        item.find(item_buttons_selector).append(generate_button);
+    };
+
+    /**
+    * Generate the notebook job/service project at `nb_path` into a given directory `to_dir` via POST
+    */
+    NotebookList.prototype.generate_nb_project = function (nb_path, pkg, version, maintainer,
+                                                       docker_repo, mesos_version, to_dir) {
+        var url = utils.url_join_encode(this.base_url, 'adastyx', nb_path, 'generate_nb_project');
+        var settings = {
+          processData: false,
+          type: "POST",
+          data: JSON.stringify({
+            type: "notebook",
+            pkg : pkg,
+            version : version,
+            maintainer : maintainer,
+            docker_repo : docker_repo,
+            mesos_version : mesos_version,
+            to_dir: to_dir
+          }),
+          dataType: "json",
+        };
+        return utils.promising_ajax(url, settings);
+    };
+
+    NotebookList.prototype.project_generated = function(name, to) {
+        $('#tabs a[href=#projects]').tab('show');
+        var alertMsg = "Project " + name + " will be generated in '" + to + "' dir!";
+        var alert = $('<div class="alert alert-success alert-dismissible" role="alert" style="margin: 5px;">\
+           <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>\
+           <strong>' + alertMsg + '.\
+         </div>');
+        $('#projects').prepend(alert);
+        setInterval(function(){ $('#refresh_project_list').click(); }, 500);
+        // alert(alertMsg);
     };
 
     NotebookList.prototype.add_duplicate_button = function (item) {

--- a/public/javascripts/adalog/tree/projectlist.js
+++ b/public/javascripts/adalog/tree/projectlist.js
@@ -1,0 +1,225 @@
+// Adastyx
+define([
+  'base/js/namespace',
+  'jquery',
+  'base/js/utils',
+  'base/js/dialog',
+], function(IPython, $, utils, dialog) {
+  "use strict";
+
+  var ProjectList = function (selector, options) {
+    this.selector = selector;
+    this.enabled = options.sbt_project_gen_enabled || utils.get_body_data("sbt_project_gen_enabled");
+    if (this.enabled === "true") {
+      this.element = $(selector);
+      this.style();
+      this.bind_events();
+    }
+    options = options || {};
+    this.options = options;
+    this.contents = options.contents;
+    this.base_url = options.base_url || utils.get_body_data("baseUrl");
+    this.log_refresher = null;
+  };
+
+  ProjectList.prototype.style = function () {
+    //$('#project_list').addClass('list_container');
+    //$('#project_toolbar').addClass('list_toolbar');
+    //$('#project_list_info').addClass('toolbar_info');
+    //$('#project_buttons').addClass('toolbar_buttons');
+  };
+
+
+  ProjectList.prototype.bind_events = function () {
+    var that = this;
+    $('#refresh_project_list').click(function () {
+      that.load_list();
+    });
+    $("#projects_logs_refresh").change(function() {
+      that.stop_refreshing_logs();
+      that.refresh_logs();
+    });
+  };
+
+  ProjectList.prototype.load_list = function () {
+    if (!this.enabled)
+      return;
+    var settings = {
+      processData : false,
+      cache : false,
+      type : "GET",
+      dataType : "json",
+      success : $.proxy(this.load_list_success, this),
+      error : utils.log_ajax_error
+    };
+    var url = utils.url_join_encode(this.base_url, 'projects');
+    $.ajax(url, settings);
+  };
+
+
+  ProjectList.prototype.clear_list = function () {
+    this.element.children('.list_item').remove();
+  };
+
+  ProjectList.prototype.load_list_success = function (data, status, xhr) {
+    this.clear_list();
+    var len = data.length;
+    for (var i=0; i<len; i++) {
+      var element = $('<div/>');
+      var item = new ProjectItem(element, this.options, this);
+      item.update_state(data[i]);
+      element.data('item', item);
+      this.element.append(element);
+    }
+  };
+
+  ProjectList.prototype.stop_refreshing_logs = function() {
+    if (this.log_refresher && this.log_refresher.interval) {
+      clearInterval(this.log_refresher.interval);
+    }
+  };
+
+  ProjectList.prototype.start_refreshing_logs = function(current) {
+    this.stop_refreshing_logs();
+    this.log_refresher = {
+      item: current
+    };
+    this.refresh_logs();
+  };
+
+  ProjectList.prototype.refresh_logs = function() {
+    var p = parseInt($("#projects_logs_refresh").val()*1000);
+    var that = this;
+    var r = function() {
+      that.log_refresher.item.load(that.log_refresher.tpe);
+    };
+    var i = setInterval(function() { r(); }, p);
+    this.log_refresher.interval = i;
+  };
+
+  var ProjectItem = function (element, options, projects) {
+    this.element = $(element);
+    this.base_url = options.base_url || utils.get_body_data("baseUrl");
+    this.notebook_path = options.notebook_path || utils.get_body_data("notebookPath");
+    this.new_notebook = options.new_notebook;
+
+    this.data = null;
+    this.cache = {
+      job: []
+    };
+    this.style();
+    this.projects = projects;
+    var that = this;
+    $('#projects_logs_lines').on("change", function (e) {
+      that.update_log_area();
+    });
+
+  };
+
+  ProjectItem.prototype.style = function () {
+    this.element.addClass('list_item').addClass("row");
+  };
+
+  ProjectItem.prototype.update_state = function (data) {
+    this.data = data;
+    this.create();
+  };
+
+  ProjectItem.prototype.load = function () {
+    var settings = {
+      processData : false,
+      cache : false,
+      type : "GET",
+      dataType : "json",
+      success : $.proxy(this.load_success(), this),
+      error : utils.log_ajax_error
+    };
+    var purl = utils.url_join_encode(this.base_url, 'projects');
+    var url = utils.url_join_encode(purl, this.data.project);
+    var c = this.cache.job;
+    url = utils.url_join_encode(url, "job");
+    url += "?from="+c.length;
+    $.ajax(url, settings);
+  };
+
+  ProjectItem.prototype.load_success = function() {
+    var that = this;
+    return function (data, status, xhr) {
+      that.cache.job = that.cache.job.concat(_.map(data.log, utils.fixConsole));
+      var n = "Job";
+      var title = $("<h4></h4>").text("Logging for " + that.data.project + ": " + n);
+      var pre = $("<div></div>").css("height", "300px")
+                                .addClass("logcontent")
+                                .css("background-color", "#fffffa")
+                                .css("overflow", "auto")
+                                .css("width", "100%")
+      var log = $("<div></div>").append(title).append(pre);
+      $("#projects_logs_panel").empty().append(log);
+      that.update_log_area();
+    };
+  };
+
+  ProjectItem.prototype.update_log_area = function() {
+    var ta = $("#projects_logs_panel div.logcontent");
+    if (!ta.length) return;
+
+    var c = this.cache.job;
+
+    var nbLogLines = parseInt($('#projects_logs_lines').val());
+    if (!c || !c.length) {
+      ta.html("<strong>No Logs!</strong>");
+    } else {
+      ta.html(_.map(c.slice(-nbLogLines), function(t) { return "<div>"+t+"</div>"; } ).join("\n"));
+    }
+  };
+
+  ProjectItem.prototype.create = function () {
+    var that = this;
+
+
+    var project_col = $('<div/>').addClass('project_col col-xs-3').text(this.data.project);
+
+    var job_col = $('<div/>')
+      .addClass('job_col col-xs-8').append(
+        '<span class="logs-refresh-button sbt-project-action"><a href="#"><i class="fa fa-refresh"></i> see build logs</a></span>'
+      );
+
+    if (this.data.zip_archive_url) {
+      job_col.append(" <a href='" + this.data.zip_archive_url + "' class='sbt-project-action'><span class='fa fa-download' aria-hidden='true'></span>download zip</a>&nbsp;&nbsp;&nbsp;");
+    }
+
+    if (this.data.git_repo_https_dir) {
+      job_col.append(" <a href='" + this.data.git_repo_https_dir + "' target='_blank' class='sbt-project-action'><i class='fa fa-code-fork' aria-hidden='true'></i>git repo</a>&nbsp;&nbsp;&nbsp;");
+    }
+
+    if (this.data.build_status) {
+      var boostrap_color = this.data.build_status;
+      project_col.addClass("text-" + boostrap_color);
+      job_col.find("a").addClass("text-" + boostrap_color);
+    }
+
+    var action_col = $('<div/>').addClass('action_col col-xs-1').text("...");
+
+    job_col.find(".logs-refresh-button").click(function(e) {
+      e.preventDefault();
+      that.load();
+      that.projects.start_refreshing_logs(that);
+    });
+
+
+    this.element.empty()
+      .append(project_col)
+      .append(job_col)
+      .append(action_col);
+  };
+
+
+  IPython.ProjectList = ProjectList;
+  IPython.ProjectItem = ProjectItem;
+
+  return {
+    'ProjectList': ProjectList,
+    'ProjectItem': ProjectItem
+  };
+
+});


### PR DESCRIPTION
this ports and opensources a prototype of a tool that `makes production-ready sbt project` from a spark-notebook.
works good in simpler cases already. In others there's minor manual adjustment needed, but this is inevitable knowing differences between Scala REPL and the compiled code.

more details in the blogpost (to come out soon) and in [README file](https://github.com/spark-notebook/spark-notebook/blob/827ca784c2fad9ae328908d1d1cdca1e57f7453d/modules/sbt-project-generator/README.md).

original discussion in #857 (postponed due to Travis issues).

---

P.S. there's still a few minor issues to solve in future, which might be done later if required:
- [ ] might need a better .gitignore
- [ ] git plugin do not delete generated files which existed earlier but no longer exists (e.g. spark-lib)
- [ ] scala 2.11: custom sbt deps & resolvers are not generated yet (scala 2.10 is fine)
- [ ] fix docker base-image URL

Ideas for further Improvements:
- [ ] UI (make accesible from edit notebook)
- [ ] optionally, mark spark as provided (maybe this could simply be a build option `sbt -Dspark.provided=true`)
