### PR TITLE
CircleCI: Fix sbt mem usage

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,9 @@
 machine:
   environment:
     SKIP_WHEN_TRAVIS: "yes"
-    SBT_OPTS: "-Xms512M -Xmx4G -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"
+    # needed to override some bad defaults, otherwise 'sbt -v' runs with only 1GB mem
+    JAVA_OPTS: "-Xms512M -Xmx4G -XX:MaxMetaspaceSize=512M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"
+    SBT_OPTS: "$JAVA_OPTS"
     BUILD_OPTS: "-Dspark.resolver.search=false" # TODO:  check 'set offline := true'
     SCALA2_10: "-Dscala.version=2.10.6"
     SCALA2_11: "-Dscala.version=2.11.8"


### PR DESCRIPTION
to prevent random out of mem crashes

**before** an unexpected `-Xmx1024m` was force added by `sbt`, see `sbt -v`

```
java
-Xms512M
-Xmx4G
-XX:+CMSClassUnloadingEnabled
-XX:+UseConcMarkSweepGC
-Xms1024m
-Xmx1024m
-XX:ReservedCodeCacheSize=128m
-XX:MaxMetaspaceSize=256m
-Dspark.version=2.0.2
-Dscala.version=2.10.6
-Dspark.resolver.search=false
-jar
/usr/share/sbt-launcher-packaging/bin/sbt-launch.jar
clean
test
```

after:
```
java
-Xms512M
-Xmx4G
-XX:MaxMetaspaceSize=512M
-XX:+CMSClassUnloadingEnabled
-XX:+UseConcMarkSweepGC
-Xms512M
-Xmx4G
-XX:MaxMetaspaceSize=512M
-XX:+CMSClassUnloadingEnabled
-XX:+UseConcMarkSweepGC
-Dspark.version=2.0.2
-Dscala.version=2.10.6
-Dspark.resolver.search=false
-jar
/usr/share/sbt-launcher-packaging/bin/sbt-launch.jar
clean
test
```