### PR TITLE
Fix default scalaVersion to 2.10.6

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,13 +39,14 @@ object Dependencies {
   val defaultSparkVersion = sys.props.getOrElse("spark.version", "2.0.1")
 
   val sparkVersionTuple = defaultSparkVersion match { case extractVs(v, m, p) =>  (v.toInt, m.toInt, p.toInt)}
-  val defaultScalaVersion = sys.props.getOrElse("scala.version", "2.11.8") match {
+  // we still see a few REPL bugs in 2.11, so still use scala 2.10 as default
+  val defaultScalaVersion = sys.props.getOrElse("scala.version", "2.10.6") match {
     case x@scala_2_1X("0") => defaultSparkVersion match {
       case spark_X_Y("2", _, _)                => "2.10.6"
       case spark_X_Y(_, _, _)                  => x
     }
     case x@scala_2_1X("1") => defaultSparkVersion match {
-      case spark_X_Y("2", _, _) => "2.11.8" // we still see a few REPL bugs in 2.11, otherwise "2.11.8"
+      case spark_X_Y("2", _, _) => "2.11.8"
       case spark_X_Y(_, _, _) => x
     }
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,7 +39,7 @@ object Dependencies {
   val defaultSparkVersion = sys.props.getOrElse("spark.version", "2.0.1")
 
   val sparkVersionTuple = defaultSparkVersion match { case extractVs(v, m, p) =>  (v.toInt, m.toInt, p.toInt)}
-  // we still see a few REPL bugs in 2.11, so still use scala 2.10 as default
+  // we still see a few REPL bugs in 2.11, so use scala 2.10 as default even if spark 2.x is focusing on 2.11
   val defaultScalaVersion = sys.props.getOrElse("scala.version", "2.10.6") match {
     case x@scala_2_1X("0") => defaultSparkVersion match {
       case spark_X_Y("2", _, _)                => "2.10.6"


### PR DESCRIPTION
fixes https://github.com/spark-notebook/spark-notebook/commit/81e8609393972b85c21452b0bd76bee0c69ba2d2 improves https://github.com/spark-notebook/spark-notebook/commit/3cb5ce14e47a9cd1f2ba786d2e04382a269b4fc1