### PR TITLE
UI: cell display improvements, fix old mathjax

### DIFF
--- a/app/views/notebook.scala.html
+++ b/app/views/notebook.scala.html
@@ -4,9 +4,9 @@
   <!-- stylesheet -->
 
   <script type="text/javascript">
-    window.mathjax_url = this.location.protocol + "//cdn.mathjax.org/mathjax/latest/MathJax.js";
+    window.mathjax_url = this.location.protocol + "//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js";
   </script>
-  <script type="text/javascript" src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML-full&delayStartupUntil=configured" charset="utf-8"></script>
+  <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML-full&delayStartupUntil=configured" charset="utf-8"></script>
 
   <link rel="stylesheet" href="@routes.Assets.at("stylesheets/third/bootstrap/css/bootstrap.css")" type="text/css" />
   <link rel="stylesheet" href="@routes.Assets.at("ipython/components/bootstrap-tour/build/css/bootstrap-tour.min.css")" type="text/css" />

--- a/modules/kernel/src/main/scala-2.10/notebook/ReplCalculator.scala
+++ b/modules/kernel/src/main/scala-2.10/notebook/ReplCalculator.scala
@@ -235,7 +235,7 @@ class ReplCalculator(
 
       result foreach {
         case (timeToEval, Success(result)) =>
-          val evalTimeStats = s"Took: $timeToEval, at ${new LocalDateTime().toString("Y-MM-d HH:mm")}"
+          val evalTimeStats = s"Took: $timeToEval, at ${new LocalDateTime().toString("Y-MM-dd HH:mm")}"
           thisSender ! ExecuteResponse(generatedReplCode.outputType, result.toString(), evalTimeStats)
         case (timeToEval, Failure(stackTrace)) =>
           thisSender ! ErrorResponse(stackTrace, incomplete = false)

--- a/modules/kernel/src/main/scala-2.11/notebook/ReplCalculator.scala
+++ b/modules/kernel/src/main/scala-2.11/notebook/ReplCalculator.scala
@@ -243,7 +243,7 @@ class ReplCalculator(
 
       result foreach {
         case (timeToEval, Success(result)) =>
-          val evalTimeStats = s"Took: $timeToEval, at ${new LocalDateTime().toString("Y-MM-d HH:mm")}"
+          val evalTimeStats = s"Took: $timeToEval, at ${new LocalDateTime().toString("Y-MM-dd HH:mm")}"
           thisSender ! ExecuteResponse(generatedReplCode.outputType, result.toString, evalTimeStats)
         case (timeToEval, Failure(stackTrace)) =>
           thisSender ! ErrorResponse(stackTrace, incomplete = false)

--- a/public/ipython/custom/custom.css
+++ b/public/ipython/custom/custom.css
@@ -152,6 +152,8 @@ h4#spark-jobs { margin-bottom: 0 !important; }
 
 /* to allow relative placement of + / - */
 div.cell { position: relative; }
+/* this is needed so edit don't get on top of context-menu buttons */
+div.cell .CodeMirror { z-index: 0; }
 div.cell.unselected div.insert-cell-btn { visibility: hidden; display: none; }
 div.cell div.insert-cell-btn a.btn { padding: 0; color: #999; }
 div.cell.selected div.insert-cell-btn { position: absolute; border: none; z-index: 1000;  }
@@ -193,7 +195,9 @@ div.output_area pre { color: #666; }
   position: absolute; top: 0; right: 0;
   background-color: #fff; border: 1px solid #eee;
   border-bottom-left-radius: 5px;
-  z-index: 9999;
+  /* we've just added this element last, instead so its on top. */
+  /* z-index do not work because of a diffrent stacking context */
+  /* z-index: 9999; */
 }
 .cell-context-buttons > .btn-group > .btn > .glyphicon { color: #aaa; }
 .cell-context-buttons .btn { padding: 0px 3px; }

--- a/public/ipython/custom/custom.css
+++ b/public/ipython/custom/custom.css
@@ -149,6 +149,16 @@ h4#spark-jobs { margin-bottom: 0 !important; }
 
 .prompt { display: none; visibility: hidden; }
 /* new cell UI */
+
+/* to allow relative placement of + / - */
+div.cell { position: relative; }
+div.cell.unselected div.insert-cell-btn { visibility: hidden; display: none; }
+div.cell div.insert-cell-btn a.btn { padding: 0; color: #999; }
+div.cell.selected div.insert-cell-btn { position: absolute; border: none; z-index: 1000;  }
+div.cell.selected div.insert-cell-btn-before { top: -12px; left: 50%; }
+div.cell.selected div.insert-cell-btn-after { bottom: -12px; left: 50%; }
+
+
 div.cell.code_cell, div.cell.text_cell {
   border-radius: 3px;
   padding: 0;

--- a/public/ipython/custom/custom.css
+++ b/public/ipython/custom/custom.css
@@ -189,6 +189,12 @@ div.cell.selected, div.cell.code_cell.selected, .edit_mode div.cell.selected {
 div.output_area pre { color: #666; }
 
 /* code cell context-menu */
+.cell-context-buttons {
+  position: absolute; top: 0; right: 0;
+  background-color: #fff; border: 1px solid #eee;
+  border-bottom-left-radius: 5px;
+  z-index: 9999;
+}
 .cell-context-buttons > .btn-group > .btn > .glyphicon { color: #aaa; }
 .cell-context-buttons .btn { padding: 0px 3px; }
 

--- a/public/ipython/notebook/js/cell.js
+++ b/public/ipython/notebook/js/cell.js
@@ -149,6 +149,12 @@ define([
         console.log("theCell-this:", theCell);
         var context_menu = $(
           '\
+          <div class="insert-cell-btn-before insert-cell-btn">\
+             <a class="btn" data-menu-command="ipython.insert-cell-before"><span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span></a>\
+          </div>\
+          <div class="insert-cell-btn-after insert-cell-btn">\
+             <a class="btn" data-menu-command="ipython.insert-cell-after"><span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span></a>\
+          </div>\
           <div class="cell-context-buttons" style="text-align: right">\
               <div class="btn-group">\
                 <a class="btn" data-menu-command="ipython.run-select-next"><span class="glyphicon glyphicon-play" aria-hidden="true"></span></a>\

--- a/public/ipython/notebook/js/codecell.js
+++ b/public/ipython/notebook/js/codecell.js
@@ -186,8 +186,6 @@ define([
         cell.attr('tabindex','2');
         cell.attr("data-cell-id", this.cell_id);
 
-        cell.prepend(this.create_context_menu());
-
         var input = $('<div></div>').addClass('input');
         var prompt = $('<div/>').addClass('prompt input_prompt');
         var inner_cell = $('<div/>').addClass('inner_cell');
@@ -251,6 +249,11 @@ define([
 
         var output = $('<div></div>');
         cell.append(input).append(widget_area).append(output).append(progress_container);
+
+        // has to be last element added to be visible on top without setting the z-index
+        // (z-index cant be used because of different stacking contexts)
+        cell.append(this.create_context_menu());
+
         this.element = cell;
         this.output_area = new outputarea.OutputArea({
             selector: output,

--- a/public/ipython/notebook/js/textcell.js
+++ b/public/ipython/notebook/js/textcell.js
@@ -90,8 +90,6 @@ define([
         var cell = $("<div>").addClass('cell text_cell');
         cell.attr('tabindex','2');
 
-        cell.prepend(this.create_context_menu());
-
         var prompt = $('<div/>').addClass('prompt input_prompt');
         cell.append(prompt);
         var inner_cell = $('<div/>').addClass('inner_cell');
@@ -114,6 +112,10 @@ define([
             .attr('tabindex','-1');
         inner_cell.append(input_area).append(render_area);
         cell.append(inner_cell);
+
+        // has to be last element added to be visible on top without setting the z-index
+        // (z-index cant be used because of different stacking contexts)
+        cell.append(this.create_context_menu());
         this.element = cell;
     };
 

--- a/public/ipython/style/style.min.css
+++ b/public/ipython/style/style.min.css
@@ -10247,7 +10247,7 @@ div#notebook_panel {
 #notebook {
   font-size: 14px;
   line-height: 20px;
-  overflow-y: hidden;
+  /* overflow-y: hidden; */
   overflow-x: auto;
   /*width: 100%;*/
   /* This spaces the page away from the edge of the notebook area */


### PR DESCRIPTION
Improve cell UI:
- Make adding cells easier - add insert-cell-after/before `(+)` buttons
- No extra line for context buttons, cell now looks more compact and consistent
- Fix visibility of context menu on the last cell


![jun 7 2017 3-06 pm](https://user-images.githubusercontent.com/213426/26877686-5fbb53d8-4b93-11e7-9d2c-4ca5ebc97359.gif)


Also:
- Migrate from old Mathjax cdn
- Fix ran-at datatime format

cc @maasg 