### PR TITLE
Speedup builds: Use coursier

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -617,7 +617,8 @@ object Application extends Controller {
         path.split("/").toList.scanLeft(("", "")) {
           case ((accPath, accName), p) => (accPath + "/" + p, p)
         }.drop(1).map { case (p, x) =>
-          Crumb(controllers.routes.Application.dash(p.tail).url, x)
+          // FIXME Reverse routes don't work with cursier: Crumb(controllers.routes.Application.dash(p.tail).url, x)
+          Crumb("/notebooks/" + p.tail, x)
         }
       ),
       Some("dashboard")

--- a/app/controllers/GeneratedSbtProjects.scala
+++ b/app/controllers/GeneratedSbtProjects.scala
@@ -58,7 +58,9 @@ object GeneratedSbtProjects extends Controller {
       val outputDir = (new File(projectManager.projectDir, generatedProject.outputDirectory.get)).toPath.toRealPath().toFile
       val projectName = generatedProject.name.get
 
-      val downloadUrl: String = controllers.routes.GeneratedSbtProjects.downloadFile(projectName, sourcesFileName).url
+      // FIXME coursier val downloadUrl: String = controllers.routes.GeneratedSbtProjects.downloadFile(projectName, sourcesFileName).url
+      val downloadUrl: String = s"/projects/$projectName/zip/$sourcesFileName"
+
       val logO: Option[Array[String]] = for {
         jobOut <- at(outputDir, "out")
       } yield fileContent(jobOut, from = 0)

--- a/build.sbt
+++ b/build.sbt
@@ -109,7 +109,7 @@ val searchSparkResolver = Option(sys.props.getOrElse("spark.resolver.search", "f
 val sparkResolver = Option(sys.props.getOrElse("spark.resolver.id", null))
 
 resolvers in ThisBuild ++= Seq(
-  Resolver.mavenLocal,
+  // FIXME: coursier don't work well with mavenLocal https://goo.gl/FeKuEo : Resolver.mavenLocal,
   Resolver.typesafeRepo("releases"),
   Resolver.sonatypeRepo("releases"),
   Resolver.typesafeIvyRepo("releases"),

--- a/docs/build_from_source.md
+++ b/docs/build_from_source.md
@@ -40,7 +40,7 @@ There is another dependency which is tricky to update, the **jets3t** one.
 
 To update that, you can pass those version as properties, here is an example with the current default ones:
 ```
-sbt -D"spark.version"="1.5.0" -D"hadoop.version"="2.6.0" -D"jets3t.version"="0.7.1" -Dmesos.version="0.24.0"
+sbt -D"spark.version"="2.1.0" -D"hadoop.version"="2.7.3" -D"jets3t.version"="0.7.1" -Dmesos.version="0.26.0"
 ```
 
 #### Create your distribution

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,7 +24,7 @@ object Dependencies {
 
   val rxScala = "io.reactivex" %% "rxscala" % "0.22.0"
 
-  val defaultHadoopVersion = sys.props.getOrElse("hadoop.version", "2.2.0")
+  val defaultHadoopVersion = sys.props.getOrElse("hadoop.version", "2.7.3")
 
   val akkaGroup = if (defaultHadoopVersion.startsWith("1")) "org.spark-project.akka" else "com.typesafe.akka"
   val akkaVersion = if (defaultHadoopVersion.startsWith("1")) "2.3.4-spark" else "2.3.11"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,10 +17,26 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-coffeescript" % "1.0.0")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.0-RC1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.3.2")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-stamp" % "5.2.0")
+
+/**
+  * coursier
+  *
+  * better and faster dependency resolution
+  * @see https://github.com/alexarchambault/coursier
+  */
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC3")
+
+/**
+  * sbt-updates
+  *
+  * for easier dependency updates monitoring
+  * @see https://github.com/rtimush/sbt-updates
+  */
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.1")


### PR DESCRIPTION
- [x] `coursier` seems to work now. Download deps in parallel and resolving seems a bit faster.
- [ ] Fix `reverse routing` or at least improve path concatenation

However `reverse routing is failing now` - had to remove usage of it. It doesn't find (controllers.routes during controller compilation). @antonkulaga any ideas here?
 
based on earlier reverted #799 (minimized dependency version changes now).