### PR TITLE
Fetch customDeps with coursier in scala-2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -109,7 +109,8 @@ val searchSparkResolver = Option(sys.props.getOrElse("spark.resolver.search", "f
 val sparkResolver = Option(sys.props.getOrElse("spark.resolver.id", null))
 
 resolvers in ThisBuild ++= Seq(
-  // FIXME: coursier don't work well with mavenLocal https://goo.gl/FeKuEo : Resolver.mavenLocal,
+  // P.S. coursier was not working well with mavenLocal (FIXED recently in 1.0.0-RC4) https://goo.gl/FeKuEo
+  Resolver.mavenLocal,
   Resolver.typesafeRepo("releases"),
   Resolver.sonatypeRepo("releases"),
   Resolver.typesafeIvyRepo("releases"),

--- a/modules/kernel/src/main/scala-2.11/notebook/ReplCalculator.scala
+++ b/modules/kernel/src/main/scala-2.11/notebook/ReplCalculator.scala
@@ -23,6 +23,7 @@ import notebook.front._
 import notebook.front.widgets._
 import notebook.repl.{ReplCommand, command_interpreters}
 import notebook.repl.command_interpreters.combineIntepreters
+import notebook.util.CoursierDeps
 
 
 /**
@@ -95,7 +96,7 @@ class ReplCalculator(
 
   val (depsJars, depsScript):(List[String],(String, ()=>String)) = customDeps.map { d =>
     val customDeps = d.mkString("\n")
-    val deps = Deps.script(customDeps, remotes, repo, notebook.BuildInfo.xSparkVersion).toOption.getOrElse(List.empty[String])
+    val deps = CoursierDeps.script(customDeps, remotes, repo, notebook.BuildInfo.xSparkVersion).toOption.getOrElse(List.empty[String])
     (deps, ("deps", () => s"""
                     |val CustomJars = ${ deps.mkString("Array(\"", "\",\"", "\")").replace("\\","\\\\") }
                     |

--- a/modules/sbt-dependency-manager/build.sbt
+++ b/modules/sbt-dependency-manager/build.sbt
@@ -37,8 +37,8 @@ libraryDependencies <++= scalaBinaryVersion {
 }
 
 libraryDependencies ++= Seq(
-  "io.get-coursier" %% "coursier" % "1.0.0-RC3",
-  "io.get-coursier" %% "coursier-cache" % "1.0.0-RC3"
+  "io.get-coursier" %% "coursier" % "1.0.0-RC4",
+  "io.get-coursier" %% "coursier-cache" % "1.0.0-RC4"
 )
 
 libraryDependencies ++= depsToDownloadDeps(scalaBinaryVersion.value, sbtVersion.value)

--- a/modules/sbt-dependency-manager/build.sbt
+++ b/modules/sbt-dependency-manager/build.sbt
@@ -36,6 +36,11 @@ libraryDependencies <++= scalaBinaryVersion {
   case "2.11" => ("com.ning" % "async-http-client" % "[1.6.5, 1.6.5]" force() exclude("org.jboss.netty", "netty"))::Nil
 }
 
+libraryDependencies ++= Seq(
+  "io.get-coursier" %% "coursier" % "1.0.0-RC3",
+  "io.get-coursier" %% "coursier-cache" % "1.0.0-RC3"
+)
+
 libraryDependencies ++= depsToDownloadDeps(scalaBinaryVersion.value, sbtVersion.value)
 
 libraryDependencies += "org.slf4j" % "slf4j-api" % "1.7.12"

--- a/modules/sbt-dependency-manager/src/main/scala-2.11/notebook/util/CoursierDeps.scala
+++ b/modules/sbt-dependency-manager/src/main/scala-2.11/notebook/util/CoursierDeps.scala
@@ -1,0 +1,89 @@
+package notebook.util
+
+import java.io.File
+
+import com.datafellas.utils.Deps
+import coursier._
+import org.slf4j.LoggerFactory
+import org.sonatype.aether.repository.RemoteRepository
+
+import scala.util.Try
+import scalaz.\/
+import scalaz.concurrent.Task
+
+
+// FIXME: do we need a unique tmp dir per Kernel session !?
+// FIXME: remove aether leftovers
+object CoursierDeps {
+
+  val DEFAULT_REPOSITORIES = Seq(Cache.ivy2Local) // in addition to ones in Deps.scala
+
+  private[this] val log = LoggerFactory.getLogger(this.getClass)
+
+  def script(cp: String,
+             remotes: List[RemoteRepository],
+             repo: java.io.File,
+             sparkVersion: String): Try[List[String]] = {
+    val (repositories, artifacts) = parseCoursierDependencies(cp, remotes, sparkVersion)
+
+    log.info("Will fetch these customDeps from repositories:" + repositories)
+    log.info("Will fetch these customDeps artifacts:" + artifacts)
+    fetchLocalJars(repositories, artifacts)
+  }
+
+  /**
+    * convert aether crap to coursier
+    * */
+  private[util] def parseCoursierDependencies(cp: String, remotes: List[RemoteRepository], sparkVersion: String): (Seq[Repository], Set[Dependency]) = {
+    val repositories = remotes.map { remote =>
+      val auth = Option(remote.getAuthentication).map(auth => coursier.core.Authentication(auth.getUsername, auth.getPassword))
+      MavenRepository(remote.getUrl, authentication = auth)
+    } ++ DEFAULT_REPOSITORIES
+
+    val (includes, excludes) = Deps.parse(cp, sparkVersion)
+    // P.S. this excludes transitive deps ignoring the `version`, however it's fine
+    // as sbt-dependency-manager in 2.10 also ignores it...
+    val exclusions: Set[(String, String)] = excludes
+      .filter(rule => rule.group.isDefined || rule.artifact.isDefined)
+      .map(rule => (rule.group.getOrElse("*"), rule.artifact.getOrElse("*")))
+    log.info("When downloading customDeps using these execusions:" + exclusions)
+
+    val artifacts = includes.map { dep =>
+      coursier.Dependency(
+        module = Module(organization = dep.group, name = dep.artifact),
+        version = dep.version,
+        exclusions = exclusions,
+        attributes = Attributes(classifier = dep.classifier.getOrElse(""))
+      )
+    }
+    (repositories, artifacts)
+  }
+
+  private def fetchLocalJars(repositories: Seq[Repository], deps: Set[Dependency]): Try[List[String]] = {
+    val resolutionStart: Resolution = coursier.Resolution(deps)
+    val fetch = Fetch.from(repositories, Cache.fetch())
+    val resolution = resolutionStart.process.run(fetch).run
+    resolution.metadataErrors.foreach { resoveError =>
+      log.error("Cannot resolve custom dependency: "+ resoveError)
+    }
+    val localArtifacts: Seq[FileError \/ File] = Task.gatherUnordered(
+      resolution.artifacts.map(Cache.file(_).run)
+    ).unsafePerformSync
+
+    collectFetchedFiles(localArtifacts.filter(_.isRight)).foreach { artifact =>
+      log.info("Fetched artifact to:" + artifact)
+    }
+
+    Try {
+      collectFetchedFiles(localArtifacts)
+        .map(_.getCanonicalFile.getAbsolutePath.toString)
+        .toList
+    }
+  }
+
+  def collectFetchedFiles(localArtifacts: Seq[FileError \/ File]): Seq[File] = {
+    localArtifacts.map { artifactOrErr =>
+      artifactOrErr.getOrElse(throw new RuntimeException("Dependency resolution failed"))
+    }.filterNot(_.getPath.endsWith(".pom"))
+  }
+}

--- a/modules/sbt-dependency-manager/src/main/scala-2.11/notebook/util/Deps.scala
+++ b/modules/sbt-dependency-manager/src/main/scala-2.11/notebook/util/Deps.scala
@@ -150,12 +150,13 @@ object Deps extends java.io.Serializable {
     case ""  => None
     case x   => Some(x)
   }
+
   def parseExclude(s:String):Option[ArtifactSelector] = {
     s.headOption.filter(_ == '-').map(_ => s.dropWhile(_=='-').trim).flatMap { line =>
       line.replaceAll("\"", "") match {
-        case PATTERN_MODULEID_1(g, "", a, v) =>
+        case PATTERN_MODULEID_1(g, "", a, v, _) =>
           Some(ArtifactSelector(parsePartialExclude(g), parsePartialExclude(a), parsePartialExclude(v)))
-        case PATTERN_MODULEID_1(g, "%", a, v) =>
+        case PATTERN_MODULEID_1(g, "%", a, v, _) =>
           Some(ArtifactSelector(parsePartialExclude(g), Some(a+"_2.11"), parsePartialExclude(v)))
         case PATTERN_COORDINATE_1(g, a, v) =>
           Some(ArtifactSelector(parsePartialExclude(g), parsePartialExclude(a), parsePartialExclude(v)))

--- a/modules/sbt-dependency-manager/src/main/scala-2.11/notebook/util/Deps.scala
+++ b/modules/sbt-dependency-manager/src/main/scala-2.11/notebook/util/Deps.scala
@@ -47,8 +47,7 @@ object Repos extends java.io.Serializable {
     mavenLocalDir.toURI.toString
   )
 
-  val config = ConfigFactory.load().getConfig("remote-repos")
-  val proxy = Try(config.getConfig("proxy")).toOption
+  val proxy = Try(ConfigFactory.load().getConfig("remote-repos").getConfig("proxy")).toOption
 
   // helper
   def apply(id:String, name:String, url:String, username:Option[String] = None, password:Option[String] = None) = {
@@ -78,7 +77,7 @@ object Repos extends java.io.Serializable {
   //alias for clarity
   def s3(id:String, name:String, url:String, key:String, secret:String) = Repos.apply(id, name, url, Some(key), Some(secret))
 
-  private[this] def mavenLocalDir: File = {
+  protected[utils] def mavenLocalDir: File = {
     val userHome = new File(System.getProperty("user.home"))
     def loadHomeFromSettings(f: () => File): Option[File] =
       try {

--- a/modules/sbt-dependency-manager/src/test/scala-2.11/notebook/util/CoursierDepsTest.scala
+++ b/modules/sbt-dependency-manager/src/test/scala-2.11/notebook/util/CoursierDepsTest.scala
@@ -1,0 +1,58 @@
+package notebook.util
+
+import com.datafellas.utils.Repos
+import coursier.{Attributes, Cache, Dependency, Module}
+import coursier.maven.MavenRepository
+import org.scalatest._
+import org.sonatype.aether.repository.RemoteRepository
+
+class CoursierDepsTest extends WordSpec with Matchers with BeforeAndAfterAll with Inside {
+  val sparkVersion = "10.0.0"
+  val version = "0.1.1"
+  val classifier = "some-classifier"
+  val scalaVer = "2.11"
+
+  // based on ReplCalculator
+  val remotes: List[RemoteRepository] = List(Repos.mavenLocal, Repos.central, Repos.sparkPackages, Repos.oss)
+
+  val (repos, deps) = CoursierDeps.parseCoursierDependencies(
+    cp =
+      s"""|com.someorg % java-artifact % $version
+          |com.someorg %% scala-artifact % $version
+          |com.someorg %% scala-artifact-cl % $version classifier $classifier
+          |- org.excludeme : excluded-artifact-mavenlike : _
+          |- org.excluded.org : _ : _
+          |- org.excludeme % excluded-artifact-java-sbtlike % _
+          |- org.excludeme %% excluded-artifact-scala-sbtlike % _
+          |- org.excludeme.sbtlike % _ % _
+          |""".stripMargin,
+    remotes = remotes,
+    sparkVersion = "2.1.1"
+  )
+
+  "yield repos" in {
+    repos shouldBe Seq(
+      MavenRepository(Repos.mavenLocal.getUrl),
+      MavenRepository("http://repo1.maven.org/maven2/"),
+      MavenRepository("http://dl.bintray.com/spark-packages/maven/"),
+      MavenRepository("https://oss.sonatype.org/content/repositories/releases/"),
+      Cache.ivy2Local
+    )
+  }
+
+  "yield dependencies with excludes (ignoring version in exclude)" in {
+    val expectedExcludes = Set(
+      ("org.excludeme", "excluded-artifact-java-sbtlike"),
+      ("org.excludeme", "excluded-artifact-scala-sbtlike_2.11"),
+      ("org.excludeme", "excluded-artifact-mavenlike"),
+      // '*' denotes an exclude by org, see https://goo.gl/mKGKoz
+      ("org.excludeme.sbtlike", "*"),
+      ("org.excluded.org", "*")
+    )
+    deps shouldBe Set(
+      Dependency(Module("com.someorg", "java-artifact"), version, exclusions = expectedExcludes),
+      Dependency(Module("com.someorg", s"scala-artifact_$scalaVer"), version, exclusions = expectedExcludes),
+      Dependency(Module("com.someorg", s"scala-artifact-cl_$scalaVer"), version, exclusions = expectedExcludes, attributes = Attributes(classifier=classifier))
+    )
+  }
+}

--- a/modules/sbt-dependency-manager/src/test/scala-2.11/notebook/util/DepsTest.scala
+++ b/modules/sbt-dependency-manager/src/test/scala-2.11/notebook/util/DepsTest.scala
@@ -4,7 +4,7 @@ import org.sonatype.aether.artifact.Artifact
 import org.sonatype.aether.util.artifact.DefaultArtifact
 import org.scalatest._
 
-class SimpleSpec extends FlatSpec with Matchers with BeforeAndAfterAll with Inside {
+class DepsTest extends FlatSpec with Matchers with BeforeAndAfterAll with Inside {
   val sparkVersion = "10.0.0"
   val groupId = "com.example"
   val artifactId = "art"
@@ -47,4 +47,20 @@ class SimpleSpec extends FlatSpec with Matchers with BeforeAndAfterAll with Insi
     val t = ArtifactMD.from(new DefaultArtifact(groupId, artifactId, classifier, "jar", version))
     checkDependencyMatch(d, t)
   }
+
+  "parse sbt style exclude" should "be parsed correctly" in {
+    val d = Deps.parseExclude(s"- $groupId % $artifactId % $version")
+    d shouldBe Some(ArtifactSelector(Some(groupId),Some(artifactId),Some(version)))
+  }
+
+  "parse sbt/scala style  exclude" should "be parsed correctly" in {
+    val d = Deps.parseExclude(s"- $groupId %% $artifactId % $version")
+    d shouldBe Some(ArtifactSelector(Some(groupId),Some(s"${artifactId}_2.11"),Some(version)))
+  }
+
+  "parse maven style exclude" should "be parsed correctly" in {
+    val d = Deps.parseExclude(s"- $groupId : $artifactId : $version")
+    d shouldBe Some(ArtifactSelector(Some(groupId),Some(artifactId),Some(version)))
+  }
+
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -31,7 +31,7 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-git-stamp" % "5.2.0")
   * better and faster dependency resolution
   * @see https://github.com/alexarchambault/coursier
   */
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC3")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC4")
 
 /**
   * sbt-updates


### PR DESCRIPTION
Dependency fetching in 2.11 is buggy due to old aether/aync-http-client (e.g. fetching fails with 403 from dl.bintray.com)
so, for now, replace it with a simpler coursier

issues:
- [x] migrate `specs2->scalatest` (get rid of scalaz dependency/conflict) https://github.com/spark-notebook/spark-notebook/pull/884
- [x] add exclusions support
- [x] add classifiers support
- [x] add ivy Local
- [x] (integration)test classifiers

Later:
- [x] fix sbt-style exclusions (unrelated for this PR: `sbt-dependency-manager` bug!)
- [ ] currently this wraps parsed `customDeps/customRepo/...` by the old lib -> need to rewrite part of customDeps handling from scratch

fixes #881  