### PR TITLE
Add auth via pac4j (single user/pass, Kerberos, and more)

### DIFF
--- a/app/filters/Filters.scala
+++ b/app/filters/Filters.scala
@@ -1,0 +1,12 @@
+package filters
+
+import javax.inject.Inject
+
+import org.pac4j.play.filters.SecurityFilter
+import play.api.http.HttpFilters
+
+class Filters @Inject()(securityFilter: SecurityFilter) extends HttpFilters {
+
+  def filters = Seq(securityFilter)
+
+}

--- a/app/modules/SecurityModule.scala
+++ b/app/modules/SecurityModule.scala
@@ -1,0 +1,92 @@
+package modules
+
+import com.google.inject.AbstractModule
+import controllers.ApplicationHacks
+import modules.authentication.SingleUserPassAuthenticator
+import org.pac4j.core.client.{BaseClient, Clients}
+import org.pac4j.core.client.direct.AnonymousClient
+import org.pac4j.core.config.Config
+import org.pac4j.core.credentials.{AnonymousCredentials, Credentials, UsernamePasswordCredentials}
+import org.pac4j.core.profile.{AnonymousProfile, CommonProfile}
+import org.pac4j.http.client.indirect.{FormClient, IndirectBasicAuthClient}
+import org.pac4j.http.credentials.authenticator.test.SimpleTestUsernamePasswordAuthenticator
+import org.pac4j.kerberos.client.indirect.IndirectKerberosClient
+import org.pac4j.play.http.DefaultHttpActionAdapter
+import org.pac4j.play.store.{PlayCacheSessionStore, PlaySessionStore}
+import org.pac4j.play.{CallbackController, LogoutController}
+import play.api.{Configuration, Environment}
+import utils.ConfigurationUtils.ConfigurationOps
+/**
+  * Guice DI module to be included in application.conf
+  */
+class SecurityModule(environment: Environment, configuration: Configuration) extends AbstractModule {
+  val kerbPrefix = "notebook.server.auth.KerberosAuthentication"
+
+  private def setupIndirectKerberosClient: IndirectKerberosClient = {
+    val conf = configuration
+    val servicePrincipal = conf.tryGetString(s"$kerbPrefix.service_principal").get
+    val serviceKeytabFile = conf.tryGetString(s"$kerbPrefix.service_keytab").get
+
+    import org.pac4j.kerberos.credentials.authenticator.{KerberosAuthenticator, SunJaasKerberosTicketValidator}
+    import org.springframework.core.io.FileSystemResource
+    val validator = new SunJaasKerberosTicketValidator()
+    validator.setServicePrincipal(servicePrincipal)
+    val keytabFile = new FileSystemResource(serviceKeytabFile)
+    if (!keytabFile.exists()){
+      throw new IllegalArgumentException(s"Keytab file '$serviceKeytabFile' do not exist")
+    }
+    validator.setKeyTabLocation(new FileSystemResource(serviceKeytabFile))
+    validator.setDebug(true)
+    validator.reinit()
+    new IndirectKerberosClient(new KerberosAuthenticator(validator))
+  }
+
+  private def createSingleUserAuthenticator = {
+    new SingleUserPassAuthenticator(configuration.getMandatoryConfig("notebook.server.auth.SingleUserPassAuthenticator"))
+  }
+
+  override def configure(): Unit = {
+    val baseUrl = configuration.getString("baseUrl").getOrElse("")
+    // modify here to any other Auth method supported by pac4j
+    val mainAuthModule = configuration.getString("notebook.server.auth.main_module").getOrElse("AnonymousClient")
+    val enabledClients = mainAuthModule match {
+      case "IndirectKerberosClient" =>
+        Seq(setupIndirectKerberosClient)
+
+      case "IndirectBasicAuthClient" =>
+        Seq(new IndirectBasicAuthClient(createSingleUserAuthenticator))
+
+      case "FormClient" =>
+        Seq(new FormClient(baseUrl + "/loginForm", createSingleUserAuthenticator))
+
+      case _ => Seq()
+    }
+
+    val clients = new Clients(baseUrl + "/callback", enabledClients: _*)
+
+    val config = new Config(clients)
+
+    //    config.addAuthorizer("admin", new RequireAnyRoleAuthorizer[Nothing]("ROLE_ADMIN"))
+    //    config.addAuthorizer("custom", new CustomAuthorizer)
+    config.setHttpActionAdapter(new DefaultHttpActionAdapter())
+    bind(classOf[Config]).toInstance(config)
+
+    // this is a hack to pass session store to controller w/o using DI
+    // FIXME: when we use proper DI in controller(s), this can be a cleaner oneliner
+    // bind(classOf[PlaySessionStore]).to(classOf[PlayCacheSessionStore])
+    import play.cache.CacheApi
+    val playCacheSessionStore: PlayCacheSessionStore = new PlayCacheSessionStore(getProvider(classOf[CacheApi]))
+    ApplicationHacks.playPac4jSessionStoreOption = Some(playCacheSessionStore)
+    bind(classOf[PlaySessionStore]).toInstance(playCacheSessionStore)
+
+    // callback
+    val callbackController = new CallbackController()
+    callbackController.setDefaultUrl("/?defaulturlafterlogout")
+    bind(classOf[CallbackController]).toInstance(callbackController)
+
+    // logout
+    val logoutController = new LogoutController()
+    logoutController.setDefaultUrl("/")
+    bind(classOf[LogoutController]).toInstance(logoutController)
+  }
+}

--- a/app/modules/authentication/SingleUserPassAuthenticator.scala
+++ b/app/modules/authentication/SingleUserPassAuthenticator.scala
@@ -1,0 +1,33 @@
+package modules.authentication
+
+import org.pac4j.core.context.{Pac4jConstants, WebContext}
+import org.pac4j.core.credentials.UsernamePasswordCredentials
+import org.pac4j.core.credentials.authenticator.Authenticator
+import org.pac4j.core.exception.CredentialsException
+import org.pac4j.core.profile.CommonProfile
+import org.pac4j.core.util.CommonHelper
+
+// based on SimpleTestUsernamePasswordAuthenticator from pac4j
+class SingleUserPassAuthenticator(authConfig: play.api.Configuration) extends Authenticator[UsernamePasswordCredentials] {
+  private val expectUser = authConfig.getString("username").get
+  private val expectPass = authConfig.getString("password").get
+
+  protected def throwException(message: String): Unit = {
+    throw new CredentialsException(message)
+  }
+
+  def validate(credentials: UsernamePasswordCredentials, context: WebContext): Unit = {
+    if (credentials == null) throwException("No credential")
+    val username = credentials.getUsername
+    val password = credentials.getPassword
+    if (CommonHelper.isBlank(username)) throwException("Username cannot be blank")
+    if (CommonHelper.isBlank(password)) throwException("Password cannot be blank")
+    if (!(expectUser == username && expectPass == password)) throwException("Invalid Username or password")
+
+    // store the logged in user in the session
+    val profile = new CommonProfile
+    profile.setId(username)
+    profile.addAttribute(Pac4jConstants.USERNAME, username)
+    credentials.setUserProfile(profile)
+  }
+}

--- a/app/views/default.scala.html
+++ b/app/views/default.scala.html
@@ -135,19 +135,18 @@
             <div id="header-container" class="container">
                 <div id="ipython_notebook" class="nav navbar-brand pull-left"><a href="@routes.Application.dash("/")" title='dashboard'><img src='@routes.Assets.at("images/logo.png")' alt='Spark Notebook'/> @project</a></div>
 
-  <!--
-  {% block login_widget %}
+
 
   <span id="login_widget">
-    {% if logged_in %}
-    <button id="logout" class="btn btn-sm navbar-btn">Logout</button>
-    {% elif login_available and not logged_in %}
-    <button id="login" class="btn btn-sm navbar-btn">Login</button>
-    {% endif %}
+    <!-- login is always forced for now -->
+    <span id="current-user-name">
+      @{ params.getOrElse("notebook-user", "") }
+    </span>
+    @if(params.getOrElse("notebook-user", "").nonEmpty) {
+      <a id="logout" class="btn btn-sm navbar-btn" href="/logout">Logout</a>
+    }
   </span>
 
-  {% endblock %}
-  -->
 
                 @headercontainer
             </div>

--- a/app/views/loginForm.scala.html
+++ b/app/views/loginForm.scala.html
@@ -1,0 +1,8 @@
+@(url: String)
+<form action="@url" method="POST">
+  <label for="username">User:</label><input id="username" type="text" name="username" value="" />
+  <br />
+  <label for="password">Password:</label><input id="password" type="password" name="password" value="" />
+  <br/>
+  <input type="submit" name="submit" value="Submit" />
+</form>

--- a/build.sbt
+++ b/build.sbt
@@ -199,6 +199,10 @@ dependencyOverrides += guava
 sharedSettings
 
 libraryDependencies ++= playDeps
+
+resolvers ++= Seq("Sonatype snapshots repository" at "https://oss.sonatype.org/content/repositories/snapshots/")
+libraryDependencies ++= pac4jSecurity
+
 libraryDependencies += scalaTest
 
 // P.S. Using static controllers with the static routes generator is not deprecated,

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -309,3 +309,52 @@ clusters {
 //  # sparkVersion = "2.0.1",
 //  #  hadoopVersion = "2.8.0"
 //}
+
+
+
+# Security with pac4j config below
+# ~~~~~
+
+# by default security is disabled
+# uncomment the following settings to enable it:
+//play.modules.enabled += "modules.SecurityModule"
+//play.http.filters = "filters.Filters"
+
+# choose auth method from: IndirectBasicAuthClient, IndirectKerberosClient, and FormClient
+# "indirect" indicates that after successful login the current user is stored in the session
+#
+# P.S. any other modules/clients supported by pac4j can be added in SecurityModule.scala
+# and pac4j supports multiple login methods at the same time too
+notebook.server.auth.main_module = "FormClient"
+
+# to enable security, you must include this:
+pac4j.security {
+  rules = [
+    # The login page(s) needs to be publicly accessible.
+    {"/loginForm.*" = {
+      authorizers = "_anonymous_"
+    }}
+    {"/callback.*" = {
+      authorizers = "_anonymous_"
+    }}
+
+    # A 'Catch all' rule to make sure the whole application stays secure.
+    {".*" = {
+      authorizers = "_authenticated_"
+      clients = ${notebook.server.auth.main_module}
+    }}
+  ]
+}
+
+# if FormClient/IndirectBasicAuthClient security enabled, configure the single user login
+# To be used with IndirectBasicAuthClient or with FormClient
+notebook.server.auth.SingleUserPassAuthenticator {
+  username = "admin"
+  password = "pass"
+}
+
+# Configure the Kerberos login, if enabled
+//notebook.server.auth.KerberosAuthentication {
+//  service_principal = "HTTP/somehost.realm.com@REALM.COM"
+//  service_keytab = "/path-to/some-protected-file.keytab"
+//}

--- a/conf/routes
+++ b/conf/routes
@@ -61,6 +61,13 @@ OPTIONS        /dockers                                  controllers.Application
 GET            /dockers                                  controllers.Application.dockerList()
 
 
+# Pac4j Authentication
+GET           /loginForm                        controllers.Application.loginForm()
+GET           /callback                         @org.pac4j.play.CallbackController.callback()
+POST          /callback                         @org.pac4j.play.CallbackController.callback()
+GET           /logout                           @org.pac4j.play.LogoutController.logout()
+
+
 # Web Sockets
 GET            /ws/observable/:contextId                 controllers.Application.openObservable(contextId:String)
 GET            /ws/api/kernels/:kernelId/channels        controllers.Application.openKernel(kernelId:String,session_id:String)

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,88 @@
+User Login (Authentication):
+----
+
+Spark-notebook supports quite a few ways to login via the [`pac4j`](https://github.com/pac4j/pac4j) and [`play-pac4j`](https://github.com/pac4j/play-pac4j) libs (but it does not store a user database by itself).
+
+Currently, the methods supported out of the box  are: 
+- `HTTP Basic`
+- `Form` (user & password login)
+- `Kerberos/SPNEGO Negotiate`
+
+and many more supported by `pac4j` (see below).
+ 
+### Selecting one of supported auth modules
+
+In `conf/application.conf`, add this:
+
+```
+# Security with pac4j config below
+# ~~~~~
+play.modules.enabled += "modules.SecurityModule"
+play.http.filters = "filters.Filters"
+
+# choose one of pac4j auth modules - this will define how user will log-in
+notebook.server.auth.main_module = "FormClient"
+//notebook.server.auth.main_module = "IndirectBasicAuthClient"
+//notebook.server.auth.main_module = "IndirectKerberosClient"
+
+# these define the URLs protected by security filters
+pac4j.security {
+  rules = [
+    # The login page(s) needs to be publicly accessible.
+    {"/loginForm.*" = {
+      authorizers = "_anonymous_"
+    }}
+    {"/callback.*" = {
+      authorizers = "_anonymous_"
+    }}
+
+    # A 'Catch all' rule to make sure the whole application stays secure.
+    {".*" = {
+      authorizers = "_authenticated_"
+      clients = ${notebook.server.auth.main_module}
+    }}
+  ]
+}
+```
+
+#### Auth with Simple Single User password
+
+If `FormClient/IndirectBasicAuthClient` is enabled, configure the single user login:
+```
+# To be used with IndirectBasicAuthClient or with FormClient
+notebook.server.auth.SingleUserPassAuthenticator {
+  username = "admin"
+  password = "pass"
+}
+```
+or, if this is not enough, you may define your own more complex authenticator (as mentioned above).
+See [`SecurityModule.scala`](../app/modules/SecurityModule.scala) file.
+
+#### Auth with Kerberos
+If enabled, you must set the keytab file and a principal in `conf/application.conf`:
+
+```
+// Configure the Kerberos login, if enabled
+notebook.server.auth.KerberosAuthentication {
+  service_principal = "HTTP/somehost.realm.com@REALM.COM"
+  service_keytab = "/path-to/some-protected-file.keytab"
+}
+```
+
+Make sure the exact service pricipal is contained in the keytab, and the keytab file is readable (but protected).
+
+Beware the errors provided by Kerberos are most of the time not intuitive at all.
+ See [`pac4j-kerberos` docs](http://www.pac4j.org/docs/clients/kerberos.html) for more details and troubleshooting.
+
+
+#### Other authentication methods
+
+With very minor additions to [`SecurityModule.scala`](../app/modules/SecurityModule.scala) file
+ one could use any of the other methods supported by [`pac4j` v2.x](https://github.com/pac4j/pac4j):
+- OAuth (Facebook, Twitter, Google...)
+- SAML
+- CAS
+- OpenID Connect  & OpenID
+- Google App Engine
+- IP address
+- and even LDAP, SQL, MongoDB, ... (as authenticators)

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,3 +16,5 @@
 	* [Building from Sources](./build_from_source.md)
 	* [Creating Specific Distributions](./build_specific_distros.md)
 	* [Creating your own custom visualizations](./custom_charts.md)
+  * [User Authentication](./authentication.md)
+    - Supports: Basic, Form & Kerberos auth, and more [(OAuth, OpendID, ...) via `pac4j` / `play-pac4j`](https://github.com/pac4j/pac4j)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -50,6 +50,16 @@ object Dependencies {
     "com.typesafe.play" %% "play-json" % "2.5.15" withSources() excludeAll(playExclusions: _*)
   ) ++ customJacksonScala
 
+  val pac4jVersion = "2.1.0-SNAPSHOT"
+  // see https://github.com/pac4j/play-pac4j-scala-demo/blob/20ccf821bc557347ca2e555fb1c85d4afea92366/build.sbt#L9-L29
+  val pac4jSecurity = Seq(
+    "org.pac4j" % "play-pac4j" % "3.0.1-SNAPSHOT" changing() excludeAll(ExclusionRule("org.pac4j", "pac4j-core")),
+    "org.pac4j" % "pac4j"  % pac4jVersion changing(),
+    "org.pac4j" % "pac4j-kerberos" % pac4jVersion changing(),
+    "org.pac4j" % "pac4j-core" % pac4jVersion changing(),
+    "org.pac4j" % "pac4j-http" % pac4jVersion changing()
+  )
+
   val rxScala = "io.reactivex" %% "rxscala" % "0.22.0"
 
   val defaultHadoopVersion = sys.props.getOrElse("hadoop.version", "2.7.3")


### PR DESCRIPTION
- Supports authentication with any of pac4j modules
- Out-of-the-box supported methods:
  * `HTTP Basic` & `Form` login (user & password)
     - there already is a simple single user/pass authenticator
     - otherwise, you need to configure a custom pac4j authenticator to validate the user/password (e.g. LDAP, SQL, MongoDB, [IP address](http://www.pac4j.org/docs/authenticators/ip.html), or write your own)
  * **`Kerberos/SPNEGO Negotiate` (!)**

<img width="930" alt="screen shot 2017-06-23 at 16 44 52" src="https://user-images.githubusercontent.com/213426/27484843-5c81ca6a-5833-11e7-9686-252a9b566646.png">


Currently, this provides only authentication/login, but more things can be based on this (e.g. `user impersonation` for Secure Hadoop will come in separate PR), 
or maybe, less likely, even a personalized `my notebooks` dashboard).


based on https://github.com/pac4j/play-pac4j-scala-demo / https://github.com/pac4j/play-pac4j

---

P.S. the Kerberos support [was recently contributed to pac4j `pac4j-kerberos`](https://github.com/pac4j/pac4j/pull/919) by the devs at [Kensu](http://www.kensu.io/) (based on an existing PR).

P.S. Some parts of the code in this PR may be improved, but that requires a huge refactoring to use Dependency-Injected controllers (see #879 ).