### PR TITLE
Pass logged-in user to Secure YARN (via proxy-user impersonation)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -330,7 +330,8 @@ lazy val subprocess = Project(id="subprocess", base=file("modules/subprocess"))
         akkaSlf4j,
         commonsIO,
         commonsExec,
-        log4j
+        log4j,
+        hadoopClient(defaultHadoopVersion)
       )
     }
   )

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -358,3 +358,13 @@ notebook.server.auth.SingleUserPassAuthenticator {
 //  service_principal = "HTTP/somehost.realm.com@REALM.COM"
 //  service_keytab = "/path-to/some-protected-file.keytab"
 //}
+
+
+# Optional: Pass the logged in user to Secure YARN cluster
+# ~~~~~
+
+# When enabled, the currently logged user which started a notebook will be passed to Hadoop/Spark.
+# This is done via impersonation (like in: spark-submit --proxy-user):
+# - the spark-notebook server is run by a single "super-user", which is impersonates itself as another user.
+# - `kinit superuser` needs to be run periodically
+notebook.hadoop-auth.proxyuser-impersonate = "true"

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,9 @@
 * [Configuration and Metadata](./metadata.md)
 	* [Using Cluster Configurations](./using_cluster_tab.md)
 * [Running on Clusters and Clouds](./clusters_clouds.md)
+  - (Secured) YARN
+  - Amazon EMR (YARN)
+  - Mesosphere DCOS (Mesos)
 * [Community](./community.md)
 * Advanced Topics
 	* [Using Releases](./using_releases.md)
@@ -18,3 +21,4 @@
 	* [Creating your own custom visualizations](./custom_charts.md)
   * [User Authentication](./authentication.md)
     - Supports: Basic, Form & Kerberos auth, and more [(OAuth, OpendID, ...) via `pac4j` / `play-pac4j`](https://github.com/pac4j/pac4j)
+    - Passing the logged in user to Secure Hadoop+YARN clusters via [`proxy-user` impersonation](./proxyuser_impersonation.md)

--- a/docs/proxyuser_impersonation.md
+++ b/docs/proxyuser_impersonation.md
@@ -1,0 +1,61 @@
+Secure Hadoop+YARN clusters & `proxy-user` impersonation
+----
+
+If spark-notebook is used by multiple users,
+ forwarding of the authenticated username is available via user impersonation 
+ (just like `--proxy-user` in `spark-submit`; see [Spark Authentication @ Cloudera](https://www.cloudera.com/documentation/enterprise/5-5-x/topics/sg_spark_auth.html#concept_bvc_pcy_dt)) 
+. This is available for YARN clusters only.
+ 
+
+## Setting-up Spark notebook
+
+Add this to `conf/application.conf` to enable forwarding:
+
+```
+# Set if the currently logged user which started a notebook kernel be passed to Hadoop/Spark?
+# This is done via impersonation (like in: spark-submit --proxy-user):
+# - the spark-notebook server is run by a single "super-user", which is impersonates itself as another user.
+# - `kinit superuser` needs to be run periodically
+notebook.hadoop-auth.proxyuser-impersonate = "true"
+```
+
+The setup would look like this:
+- `spark-notebook` server is run by user `sparknotebook` (which has `proxyuser` privillege)
+  * once `proxyuser-impersonate` enabled, notebooks would run in name of another user, the one who started the notebook's kernel/REPL.
+- one would periodically run `kinit` from the same `sparknotebook` user, to make the Kerberos credentials of the base-user available so it could access the secure cluster
+  * e.g. add this command to cron: `kinit -V -k -t /some-path/spark.headless.keytab -r 7d spark@somerealm.com`
+
+
+## Seting up Secure Hadoop/Spark @ YARN
+
+### Setup secure YARN
+### Enable impersonation for `sparknotebook` user
+
+  Add something like this to `core-site.xml` (likely you want to explicitly list the allowed users/groups/hosts):
+  ```xml
+     <property>
+       <name>hadoop.proxyuser.sparknotebook.hosts</name>
+       <value>*</value>
+     </property>
+     <property>
+       <name>hadoop.proxyuser.sparknotebook.users</name>
+       <value>*</value>
+     </property>
+     <property>
+       <name>hadoop.proxyuser.sparknotebook.groups</name>
+       <value>*</value>
+     </property>
+  ```
+### Setup Spark Notebook for YARN.
+
+See [`Secured YARN clusters` section here](./clusters_clouds.md) for a few notes on 
+how to set up a spark-notebook on a secured YARN cluster.
+
+```bash
+# useful when debugging (do not use in production)
+# print extra info about current Kerberos user/errors
+export HADOOP_JAAS_DEBUG=true
+```
+
+### Notes
+P.S. Hadoop authentication via keytab (i.e. `--keytab` & `--pricipal` in `spark-submit`) is not supported as it works only in `YARN-cluster` mode, which is problematic in REPL (and even `spark-shell` don't support it).   

--- a/modules/subprocess/src/main/scala/notebook/Kernel.scala
+++ b/modules/subprocess/src/main/scala/notebook/Kernel.scala
@@ -21,7 +21,8 @@ class Kernel(
   system: ActorSystem,
   kernelId: String,
   notebookPath_ : Option[String] = None,
-  customArgs:Option[List[String]]
+  customArgs:Option[List[String]],
+  impersonatedUser: Option[String] = None
 ) {
   private[this] var _notebookPath = notebookPath_
 
@@ -50,7 +51,7 @@ class Kernel(
     private var remoteActorSystemm: RemoteActorSystem = null
 
     override def preStart() {
-      remoteActorSystemm = Await.result(RemoteActorSystem.spawn(config, system, "kernel", kernelId, notebookPath, customArgs), 1 minutes)
+      remoteActorSystemm = Await.result(RemoteActorSystem.spawn(config, system, "kernel", kernelId, notebookPath, customArgs, impersonatedUser), 1 minutes)
       remoteDeployPromise.success(remoteActorSystemm.deploy)
     }
 

--- a/modules/subprocess/src/main/scala/notebook/kernel/remote/RemoteActorSystem.scala
+++ b/modules/subprocess/src/main/scala/notebook/kernel/remote/RemoteActorSystem.scala
@@ -94,11 +94,16 @@ class RemoteActorSystem(localSystem: ActorSystem, info: ProcessInfo, remoteConte
 object RemoteActorSystem {
   val nextId = new AtomicInteger(1)
 
-  def spawn(config: Config, system: ActorSystem, configFile: String, kernelId: String,
-    notebookPath: Option[String], customArgs:Option[List[String]]): Future[RemoteActorSystem] = {
+  def spawn(config: Config,
+            system: ActorSystem,
+            configFile: String,
+            kernelId: String,
+            notebookPath: Option[String],
+            customArgs:Option[List[String]],
+            impersonatedUser: Option[String]): Future[RemoteActorSystem] = {
     val cookiePath = ""
     new BetterFork[RemoteActorProcess](config, system.dispatcher, customArgs)
-      .execute(kernelId, notebookPath.getOrElse("no-path"), configFile, cookiePath)
+      .execute(kernelId, notebookPath.getOrElse("no-path"), impersonatedUser.getOrElse("NONE"), configFile, cookiePath)
       .map {
         new RemoteActorSystem(system, _)
       }

--- a/public/docs/clusters_clouds.html
+++ b/public/docs/clusters_clouds.html
@@ -3,7 +3,7 @@
 </head>
 <body><h1 id="documentation">Documentation</h1>
 <h2 id="clusters-clouds">Clusters / Clouds</h2>
-<h3 id="amazon-emr">Amazon EMR</h3>
+<h3 id="amazon-emr">Amazon EMR (YARN)</h3>
 <h4 id="description">Description</h4>
 <p>You can on Amazon EMR launch Spark Clusters from this <a href="https://console.aws.amazon.com/elasticmapreduce/">page</a> or using the <a href="https://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/emr-spark-launch.html">AWS CLI</a>.</p>
 <p><strong>NOTE</strong>: For reproductability, the notebook which was already created including examples use its own metadata. Hence you will need to create a new notebook that will be applied the template from application.conf as explained below or you have to change the metadata of the exisiting one([Edit] -&gt; [Edit Notebook Metadata]).</p>


### PR DESCRIPTION
- Adds an option to pass the currently logged in user to a YARN/Hadoop cluster.
  * Works just like `--proxy-user someuser` in `spark-shell`.
  * This requires `kinit` to be periodically run for the user which started the `spark-notebook` server (see docs).

P.S. The proxy user is used by `spark`, but it is lost in any subprocess, e.g. `:sh`.
