### PR TITLE
Add -Dwith.mesos=true option

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -90,6 +90,23 @@ object Dependencies {
     ExclusionRule("javax.servlet", "javax.servlet-api")
   )
 
+  val defaultWithMesos = sys.props.getOrElse("with.mesos", "true").toBoolean
+
+  def sparkMesos(v: String) = {
+    if (!defaultWithMesos) {
+      Seq()
+    } else {
+      v match {
+        case spark_X_Y("1", _, _) => Seq()
+        case spark_X_Y("2", "0", _) => Seq()
+        case _ => // since spark 2.1.x, we should add spark-mesos:
+          Seq(
+            "org.apache.spark" %% "spark-mesos" % v
+          )
+      }
+    }
+  }
+
   def hadoopClient(v: String) = "org.apache.hadoop" % "hadoop-client" % v excludeAll(
     ExclusionRule("org.apache.commons", "commons-exec"),
     ExclusionRule("commons-codec", "commons-codec"),

--- a/project/Shared.scala
+++ b/project/Shared.scala
@@ -82,7 +82,7 @@ object Shared {
                 "org.eclipse.jetty" % "jetty-server"       % jettyVersion
               )
             } else Nil
-          )
+          ) ++ sparkMesos(sv)
       libs
     }
   ) ++ repl ++ hive ++ yarnWebProxy

--- a/run-dev.sh
+++ b/run-dev.sh
@@ -36,5 +36,6 @@ HADOOP_CONF_DIR=/etc/hadoop/conf:/etc/hive/conf sbt \
   -Dconfig.file=${CONFIG_FILE} \
   -Dwith.hive=true \
   -Dwith.parquet=true \
+  -Dwith.mesos=true \
   -Dmanager.notebooks.override.sparkConf.spark.port.maxRetries=100 \
   clean run


### PR DESCRIPTION
Since Spark 2.1.0+ `spark-mesos` is a separate lib

- [x] test `master=mesos://...` is resolved (didn't do a very through test)
- [x] test `yarn` still works, when mesos libs included