### PR TITLE
Removing the VOLUMES from the 'Dockerfile' (config of docker sbt plugin)

### DIFF
--- a/project/DockerProperties.scala
+++ b/project/DockerProperties.scala
@@ -18,7 +18,7 @@ object DockerProperties extends BuildConf {
     Cmd("RUN", s"apt-get install -y wget curl")
   )
 
-  private val defaultVolumes: Seq[String] = Seq("/opt/docker", "/opt/docker/notebooks", "/opt/docker/logs")
+  private val defaultVolumes: Seq[String] = Seq()
 
   private def asCmdSeq( configs: Seq[Config] ): Seq[Cmd] = {
     configs.flatMap { possibleCmd =>


### PR DESCRIPTION
The reason for this is that once the volume is added, it's not possible
to remove it in the children images.

I wanted to make this image running in OpenShift and OpenShift runs all
the docker images as non-root user with random UID, this results in
issue that PID file cannot be created in the /opt/docker directory.
Luckily, this can be workarounded by -Dpidfile.path=/tmp/pid param.

What cannot be workarounded is the fact that the default docker image
defines these 3 volumes: "/opt/docker", "/opt/docker/notebooks",
 "/opt/docker/logs". And that they are not disjunctive => on OpenShift
there was no /opt/docker/bin directory with the start script.

Note: that docker volumes can still be added in runtime

This is related issue on the Docker side https://github.com/moby/moby/issues/3465