### PR TITLE
Fix copy&paste in readOnly mode

### DIFF
--- a/public/ipython/notebook/js/notebook.js
+++ b/public/ipython/notebook/js/notebook.js
@@ -2225,7 +2225,7 @@ define([
         var failed, msg;
         // we want cell/cm_config options to be set before creating them from JSON...
         this.writable = data.writable && !this.is_read_only();
-        this.config.cm_config = { readOnly: !this.writable && "nocursor" };
+        this.config.cm_config = { readOnly: !this.writable };
 
         try {
             this.fromJSON(data);


### PR DESCRIPTION
this adds a blinking cursor, but better than broken coopy&paste.

`readOnly="nocursor"` seem to have buggy in codemirror.
see https://github.com/codemirror/CodeMirror/issues/2568 https://github.com/codemirror/CodeMirror/issues/1099

fixes https://github.com/spark-notebook/spark-notebook/issues/937

@antonkulaga