### PR TITLE
Set max-classfile-name in compiler args. Fixes #899

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -161,7 +161,7 @@ manager {
     # for more explicit warnings about "optional" language features that
     # should be enabled explicitly. One of those that's used by Spark Notebook
     # itself is "reflective calls".
-    compilerArgs=["-deprecation", "-feature", "-language:reflectiveCalls"]
+    compilerArgs=["-deprecation", "-feature", "-language:reflectiveCalls", "-Xmax-classfile-name", "240"]
   }
 
   clusters {


### PR DESCRIPTION
Since Docker builds are part of the standard distributions, spark-notebook should cater for the fact that Docker on Ubuntu (AUFS) limits filenames to a max of 242 characters. Therefore limit the flag.