### PR TITLE
Fix cell spark job status bar: new cell id on each run

### DIFF
--- a/public/ipython/notebook/js/codecell.js
+++ b/public/ipython/notebook/js/codecell.js
@@ -480,6 +480,14 @@ define([
         var callbacks = this.get_callbacks();
 
         var old_msg_id = this.last_msg_id;
+
+        // update cell UUID at each run (so spark job progress is reported only for the most recent run)
+        this.cell_id = utils.uuid();
+        // update cell metadata which triggers the update of data-cell-id DOM attribute
+        var md = this.metadata;
+        md.id = this.cell_id;
+        this.metadata = md;
+
         var cell_id = this.cell_id;
         this.last_msg_id = this.kernel.execute(
           this.get_text(),

--- a/public/javascripts/notebook/job_progress.js
+++ b/public/javascripts/notebook/job_progress.js
@@ -36,7 +36,7 @@ define([
       function findCells(id) {
         var f = ".cell[data-cell-id"+(id?"='"+id+"'":"")+"]";
         var cells = $(IPython.notebook.element).find(f);
-        return _.object(_.map(cells, function(cell) {return [$(cell).data("cell-id"), cell]}));
+        return _.object(_.map(cells, function(cell) {return [$(cell).attr("data-cell-id"), cell]}));
       }
 
       progress.subscribe(function(status) {
@@ -60,15 +60,18 @@ define([
           var totalTasks = sum(_.pluck(jobs, 'total_tasks'));
           var cellProgress = Math.min(Math.floor(completedTasks * 100.0 / totalTasks), 100);
           if (cell_id) {
-            var cell = $(cells[cell_id]).data("cell");
-            var cellProgressBar = $(cells[cell_id]).find('div.progress-bar');
-            cellProgressBar.css("width", Math.max(cellProgress, 5) + "%");
-            if (cellProgress == 100) {
-              cellProgressBar.removeClass("active").removeClass("progress-bar-striped");
-              if (cell) cell.hideCancelCellBtn();
-            } else {
-              cellProgressBar.addClass("active").addClass("progress-bar-striped");
-              if (cell) cell.addCancelCellBtn();
+            // now old cell runs have cell ids which are non-existent anymore (as each run gets new cell id)
+            if (cells[cell_id] !== undefined) {
+              var cell = $(cells[cell_id]).data("cell");
+              var cellProgressBar = $(cells[cell_id]).find('div.progress-bar');
+              cellProgressBar.css("width", Math.max(cellProgress, 5) + "%");
+              if (cellProgress == 100) {
+                cellProgressBar.removeClass("active").removeClass("progress-bar-striped");
+                if (cell) cell.hideCancelCellBtn();
+              } else {
+                cellProgressBar.addClass("active").addClass("progress-bar-striped");
+                if (cell) cell.addCancelCellBtn();
+              }
             }
           }
         });


### PR DESCRIPTION
change cell id on every cell run. this fixes the cell's spark job status bar when cells are run multiple times.

earlier the cell ID was always fixed, so job progresses were *incorrectly accumulated* among all previous runs of the same cell, so on 2nd, 3rd etc run the status bar would start at 50%, 66% etc.

cc @andypetrella 

